### PR TITLE
feat: arch mismatch detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,12 +139,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create GitHub Release
+      - name: Update GitHub Release Notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
-          gh release create "$TAG" \
-            --title "Release $TAG" \
-            --generate-notes \
-            release/*
+          NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes -f tag_name="$TAG" --jq '.body')
+          gh release edit "$TAG" --title "Release $TAG" --notes "$NOTES"

--- a/cmd/deps/main.go
+++ b/cmd/deps/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/flanksource/deps/cmd"
+	"github.com/flanksource/deps/pkg/installer"
 )
 
 var (
@@ -16,6 +18,10 @@ var (
 func main() {
 	cmd.SetVersion(version, commit, date, dirty)
 	if err := cmd.Execute(); err != nil {
+		var vme *installer.VersionMismatchError
+		if errors.As(err, &vme) {
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 }

--- a/deps.go
+++ b/deps.go
@@ -14,13 +14,14 @@ import (
 
 // Re-export commonly used types for public API
 type (
-	InstallResult = types.InstallResult
-	InstallStatus = types.InstallStatus
-	VerifyStatus  = types.VerifyStatus
-	VersionStatus = types.VersionStatus
-	Package       = types.Package
-	RunOptions    = runtime.RunOptions
-	RunResult     = runtime.RunResult
+	InstallResult        = types.InstallResult
+	InstallStatus        = types.InstallStatus
+	VerifyStatus         = types.VerifyStatus
+	VersionStatus        = types.VersionStatus
+	Package              = types.Package
+	RunOptions           = runtime.RunOptions
+	RunResult            = runtime.RunResult
+	VersionMismatchError = installer.VersionMismatchError
 )
 
 // Re-export status constants

--- a/pkg/config/config_ginkgo_test.go
+++ b/pkg/config/config_ginkgo_test.go
@@ -8,6 +8,16 @@ import (
 )
 
 var _ = Describe("Config", func() {
+	Describe("LoadDefaultConfig", func() {
+		It("should load embedded defaults.yaml without error", func() {
+			config, err := LoadDefaultConfig()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(config.Registry)).To(BeNumerically(">", 50))
+			Expect(config.Registry).To(HaveKey("powershell"))
+			Expect(config.Registry).To(HaveKey("step"))
+		})
+	})
+
 	Describe("Package Defaults", func() {
 		Context("when applying package defaults", func() {
 			It("should set name to registry key when name is empty", func() {

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -286,6 +286,8 @@ registry:
         asset_patterns:
             "linux-*": "kube-apiserver"
             "darwin-*,windows-*": "https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-{{.tag}}/envtest-{{.tag}}-{{.os}}-{{.arch}}.tar.gz"
+        version_fallback: |
+            os == "linux" ? version : version.split(".")[0] + "." + version.split(".")[1] + ".0"
         binary_path: |
             os in ["darwin", "windows"] ? "controller-tools/envtest/kube-apiserver" : ""
         checksum_file: |
@@ -442,7 +444,7 @@ registry:
             darwin-arm64: powershell-{{.version}}-osx-arm64.tar.gz
             linux-amd64: powershell-{{.version}}-linux-x64.tar.gz
             linux-arm64: powershell-{{.version}}-linux-arm64.tar.gz
-        version_command: --version
+        version_command: ./pwsh --version
         version_regex: 'PowerShell (\S+)'
         post_process:
             - chmod("pwsh", "0755")
@@ -859,5 +861,5 @@ registry:
         symlinks:
             - uv
             - uvx
-        version_command: --version
+        version_command: uv --version
         version_regex: 'uv (\d+\.\d+\.\d+)'

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -201,7 +201,6 @@ registry:
         version_regex: .*Version:\s+v?(\d+\.\d+\.\d+)
     postgrest:
         name: postgrest
-
         repo: PostgREST/postgrest
         asset_patterns:
             darwin-amd64: postgrest-{{.tag}}-macos-x86-64.tar.xz

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -33,7 +33,7 @@ registry:
             linux-arm64: jq-linux-arm64
             windows-amd64: jq-win64.exe
         version_command: --version
-        version_regex: jq-(\d+\.\d+)
+        version_regex: jq-(\d+\.\d+\.\d+)
 
     kubectl:
         name: kubectl
@@ -829,9 +829,9 @@ registry:
             darwin-amd64: clickhouse-macos
             darwin-arm64: clickhouse-macos-aarch64
         version_expr: |
-            (tag.contains("-stable") || tag.contains("-lts")) ? (tag.substring(1).split("-")[0].split(".").size() >= 4 ? tag.substring(1).split("-")[0].split(".")[0] + "." + tag.substring(1).split("-")[0].split(".")[1] + "." + tag.substring(1).split("-")[0].split(".")[2] + "+" + tag.substring(1).split("-")[0].split(".")[3] : tag.substring(1).split("-")[0]) : ""
+            (tag.contains("-stable") || tag.contains("-lts")) ? tag.substring(1).split("-")[0] : ""
         version_command: client --version
-        version_regex: ClickHouse client version (\d+\.\d+\.\d+)
+        version_regex: ClickHouse client version (\d+\.\d+\.\d+\.\d+)
 
     step:
         name: step

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -170,7 +170,7 @@ registry:
             linux-amd64: svu_{{.version}}_linux_amd64.tar.gz
             linux-arm64: svu_{{.version}}_linux_arm64.tar.gz
         version_command: --version
-        version_regex: svu\s+version\s+v?(\d+\.\d+\.\d+)
+        version_regex: 'GitVersion:\s+v?(\d+\.\d+\.\d+)'
     canary-checker:
         name: canary-checker
 
@@ -442,8 +442,8 @@ registry:
             darwin-arm64: powershell-{{.version}}-osx-arm64.tar.gz
             linux-amd64: powershell-{{.version}}-linux-x64.tar.gz
             linux-arm64: powershell-{{.version}}-linux-arm64.tar.gz
-        version_command: ./pwsh --version
-        version_regex: PowerShell (\S+)
+        version_command: --version
+        version_regex: 'PowerShell (\S+)'
         post_process:
             - chmod("pwsh", "0755")
         symlinks:
@@ -615,7 +615,7 @@ registry:
             "*": tomee-{{.version}}/apache-tomee-{{.version}}-plume.zip
         checksum_file: "{{.asset}}.sha512"
         version_command: bash -c 'bin/tomee version 2>/dev/null | grep TomEE'
-        version_regex: 'Server version:.*TomEE/([\\d\\.]+)'
+        version_regex: 'Server version:.*TomEE/([\d.]+)'
         symlinks:
             - tomee->bin/catalina.sh
         post_process:
@@ -631,7 +631,7 @@ registry:
             "*": apache-activemq-{{.version}}-bin.zip
         checksum_file: "{{.asset}}.sha512"
         version_command: bin/activemq --version
-        version_regex: 'ActiveMQ\\s+(\\d+\\.\\d+\\.\\d+)'
+        version_regex: 'ActiveMQ\s+(\d+\.\d+\.\d+)'
         symlinks:
             - bin/activemq
         post_process:
@@ -650,7 +650,7 @@ registry:
             "*": apache-artemis-{{.version}}-bin.tar.gz
         checksum_file: apache-artemis-{{.version}}-bin.tar.gz.sha512
         version_command: bin/artemis version
-        version_regex: 'ActiveMQ Artemis\\s+(\\d+\\.\\d+\\.\\d+)'
+        version_regex: 'ActiveMQ Artemis\s+(\d+\.\d+\.\d+)'
         symlinks:
             - bin/artemis
 
@@ -859,5 +859,5 @@ registry:
         symlinks:
             - uv
             - uvx
-        version_command: uv --version
+        version_command: --version
         version_regex: 'uv (\d+\.\d+\.\d+)'

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -563,9 +563,11 @@ registry:
             linux-amd64: OpenJDK8U-jdk_x64_linux_hotspot_{{.tag | strings.TrimPrefix "jdk" | strings.ReplaceAll "-" ""}}.tar.gz
             linux-arm64: OpenJDK8U-jdk_aarch64_linux_hotspot_{{.tag | strings.TrimPrefix "jdk" | strings.ReplaceAll "-" ""}}.tar.gz
         version_command: java -version
-        version_regex: '8u(\d+)'
+        version_regex: '([\d._]+)'
         # Transform jdk8u472-b08 -> 8.0.472+8 for semver sorting, exclude beta and non-jdk8u tags
         version_expr: 'tag.startsWith("jdk8u") && !tag.contains("beta") ? "8.0." + tag.split("-")[0].substring(5) + "+" + tag.split("-")[1].substring(1) : ""'
+        verify_expr: |
+            installed == expected || installed.startsWith("1.8.0") || installed.startsWith("8.0.")
         symlinks:
             - "darwin-*: Contents/Home/bin/*"
             - "linux-*: bin/*"

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -7,32 +7,34 @@ import (
 var globalRegistry *types.DepsConfig
 
 func init() {
-	// Load defaults + user config during package initialization
+	initGlobalRegistry()
+}
+
+func initGlobalRegistry() {
 	defaultConfig, err := LoadDefaultConfig()
 	if err != nil {
-		// If we can't load defaults, create minimal config
 		defaultConfig = &types.DepsConfig{
 			Registry:     make(map[string]types.Package),
 			Dependencies: make(map[string]string),
 		}
 	}
 
-	// Try to load user config
 	userConfig, err := loadRawConfig("")
 	if err != nil {
-		// If user config doesn't exist, just use defaults
 		globalRegistry = defaultConfig
 	} else {
-		// Merge configs
 		globalRegistry = MergeWithDefaults(defaultConfig, userConfig)
 	}
 
-	// Apply post-processing (same logic as LoadMergedConfig)
 	applyConfigPostProcessing(globalRegistry)
 }
 
-// GetGlobalRegistry returns the pre-loaded global registry (defaults + user config)
+// GetGlobalRegistry returns the pre-loaded global registry (defaults + user config).
+// If the registry is nil (e.g., after ResetGlobalRegistry), it re-initializes from defaults.
 func GetGlobalRegistry() *types.DepsConfig {
+	if globalRegistry == nil {
+		initGlobalRegistry()
+	}
 	return globalRegistry
 }
 

--- a/pkg/installer/errors.go
+++ b/pkg/installer/errors.go
@@ -1,0 +1,11 @@
+package installer
+
+import "fmt"
+
+type VersionMismatchError struct {
+	Tool, Expected, Got string
+}
+
+func (e *VersionMismatchError) Error() string {
+	return fmt.Sprintf("%s: version mismatch — installed %s, expected %s", e.Tool, e.Got, e.Expected)
+}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -841,19 +841,38 @@ func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg 
 	isAlias := resolvedVersion == "stable" || resolvedVersion == "latest" || resolvedVersion == "any"
 	if pkg.VersionCommand != "" && !isCrossPlatform && !isAlias {
 		t.SetDescription("Verifying installed version")
-		result := versionpkg.CheckBinaryVersion(t, pkg.Name, pkg, i.options.BinDir, resolvedVersion, resolvedVersion)
-		if result.Status == types.CheckStatusError {
-			binPath := filepath.Join(i.options.BinDir, filepath.Base(finalPath))
-			if diagMsg := pipeline.DiagnoseLibraryIssues(binPath, t); diagMsg != "" {
-				return fmt.Errorf("%s: version check failed: %s\n%s", pkg.Name, result.Error, diagMsg)
+
+		// Resolve binary path and version command using the same logic as CheckExistingInstallation
+		binPath := finalPath
+		versionCmd := pkg.VersionCommand
+		versionCheckMode := pkg.Mode
+
+		// For directory-mode with symlinks, resolve through the symlink in bin-dir
+		if pkg.Mode == "directory" && len(pkg.Symlinks) > 0 && !versionpkg.ContainsShellOperators(pkg.VersionCommand) {
+			cmdParts := strings.Fields(pkg.VersionCommand)
+			if len(cmdParts) > 0 && cmdParts[0] != "bash" && cmdParts[0] != "sh" {
+				symlinkPath := filepath.Join(i.options.BinDir, filepath.Base(cmdParts[0]))
+				if _, err := os.Stat(symlinkPath); err == nil {
+					binPath = symlinkPath
+					versionCmd = strings.Join(cmdParts[1:], " ")
+					versionCheckMode = ""
+				}
 			}
-			return fmt.Errorf("%s: version check failed: %s", pkg.Name, result.Error)
 		}
-		if result.Status != types.CheckStatusOK && result.Status != types.CheckStatusNewer {
+
+		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, binPath, versionCmd, pkg.VersionRegex, versionCheckMode)
+		if versionErr != nil {
+			if diagMsg := pipeline.DiagnoseLibraryIssues(binPath, t); diagMsg != "" {
+				return fmt.Errorf("%s: version check failed: %w\n%s", pkg.Name, versionErr, diagMsg)
+			}
+			return fmt.Errorf("%s: version check failed: %w", pkg.Name, versionErr)
+		}
+		status, _ := versionpkg.CompareVersions(installedVersion, resolvedVersion)
+		if status != types.CheckStatusOK && status != types.CheckStatusNewer {
 			return &VersionMismatchError{
 				Tool:     pkg.Name,
 				Expected: resolvedVersion,
-				Got:      result.InstalledVersion,
+				Got:      installedVersion,
 			}
 		}
 	}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -860,19 +860,35 @@ func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg 
 			}
 		}
 
-		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, binPath, versionCmd, pkg.VersionRegex, versionCheckMode)
+		installedVersion, rawOutput, versionErr := versionpkg.GetInstalledVersionWithMode(t, binPath, versionCmd, pkg.VersionRegex, versionCheckMode)
 		if versionErr != nil {
 			if diagMsg := pipeline.DiagnoseLibraryIssues(binPath, t); diagMsg != "" {
 				return fmt.Errorf("%s: version check failed: %w\n%s", pkg.Name, versionErr, diagMsg)
 			}
 			return fmt.Errorf("%s: version check failed: %w", pkg.Name, versionErr)
 		}
-		status, _ := versionpkg.CompareVersions(installedVersion, resolvedVersion)
-		if status != types.CheckStatusOK && status != types.CheckStatusNewer {
-			return &VersionMismatchError{
-				Tool:     pkg.Name,
-				Expected: resolvedVersion,
-				Got:      installedVersion,
+
+		if pkg.VerifyExpr != "" {
+			plat := i.getPlatform()
+			ok, verifyErr := versionpkg.EvaluateVerifyExpr(pkg.VerifyExpr, installedVersion, resolvedVersion, rawOutput, plat.OS, plat.Arch)
+			if verifyErr != nil {
+				return fmt.Errorf("%s: verify_expr failed: %w", pkg.Name, verifyErr)
+			}
+			if !ok {
+				return &VersionMismatchError{
+					Tool:     pkg.Name,
+					Expected: resolvedVersion,
+					Got:      installedVersion,
+				}
+			}
+		} else {
+			status, _ := versionpkg.CompareVersions(installedVersion, resolvedVersion)
+			if status != types.CheckStatusOK && status != types.CheckStatusNewer {
+				return &VersionMismatchError{
+					Tool:     pkg.Name,
+					Expected: resolvedVersion,
+					Got:      installedVersion,
+				}
 			}
 		}
 	}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -840,29 +840,20 @@ func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg 
 		(i.options.ArchOverride != "" && i.options.ArchOverride != runtime.GOARCH)
 	isAlias := resolvedVersion == "stable" || resolvedVersion == "latest" || resolvedVersion == "any"
 	if pkg.VersionCommand != "" && !isCrossPlatform && !isAlias {
-		// Use full path in bin-dir for version check
-		binPath := filepath.Join(i.options.BinDir, filepath.Base(finalPath))
-		if _, err := os.Stat(binPath); err != nil {
-			binPath = finalPath // fallback to finalPath if not in bin-dir
-		}
 		t.SetDescription("Verifying installed version")
-		versionCheckMode := pkg.Mode
-		if pkg.Mode == "directory" && binPath != finalPath {
-			versionCheckMode = ""
-		}
-		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, binPath, pkg.VersionCommand, pkg.VersionRegex, versionCheckMode)
-		if versionErr != nil {
+		result := versionpkg.CheckBinaryVersion(t, pkg.Name, pkg, i.options.BinDir, resolvedVersion, resolvedVersion)
+		if result.Status == types.CheckStatusError {
+			binPath := filepath.Join(i.options.BinDir, filepath.Base(finalPath))
 			if diagMsg := pipeline.DiagnoseLibraryIssues(binPath, t); diagMsg != "" {
-				return fmt.Errorf("%s: version check failed: %w\n%s", pkg.Name, versionErr, diagMsg)
+				return fmt.Errorf("%s: version check failed: %s\n%s", pkg.Name, result.Error, diagMsg)
 			}
-			return fmt.Errorf("%s: version check failed: %w", pkg.Name, versionErr)
+			return fmt.Errorf("%s: version check failed: %s", pkg.Name, result.Error)
 		}
-		status, _ := versionpkg.CompareVersions(installedVersion, resolvedVersion)
-		if status != types.CheckStatusOK && status != types.CheckStatusNewer {
+		if result.Status != types.CheckStatusOK && result.Status != types.CheckStatusNewer {
 			return &VersionMismatchError{
 				Tool:     pkg.Name,
 				Expected: resolvedVersion,
-				Got:      installedVersion,
+				Got:      result.InstalledVersion,
 			}
 		}
 	}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -834,11 +835,20 @@ func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg 
 	}
 
 	// Verify installed version matches expected
-	if pkg.VersionCommand != "" {
+	// Skip for: cross-platform installs (can't execute), version aliases (nothing concrete to compare)
+	isCrossPlatform := (i.options.OSOverride != "" && i.options.OSOverride != runtime.GOOS) ||
+		(i.options.ArchOverride != "" && i.options.ArchOverride != runtime.GOARCH)
+	isAlias := resolvedVersion == "stable" || resolvedVersion == "latest" || resolvedVersion == "any"
+	if pkg.VersionCommand != "" && !isCrossPlatform && !isAlias {
+		// Use full path in bin-dir for version check
+		binPath := filepath.Join(i.options.BinDir, filepath.Base(finalPath))
+		if _, err := os.Stat(binPath); err != nil {
+			binPath = finalPath // fallback to finalPath if not in bin-dir
+		}
 		t.SetDescription("Verifying installed version")
-		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, finalPath, pkg.VersionCommand, pkg.VersionRegex, pkg.Mode)
+		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, binPath, pkg.VersionCommand, pkg.VersionRegex, pkg.Mode)
 		if versionErr != nil {
-			if diagMsg := pipeline.DiagnoseLibraryIssues(finalPath, t); diagMsg != "" {
+			if diagMsg := pipeline.DiagnoseLibraryIssues(binPath, t); diagMsg != "" {
 				return fmt.Errorf("%s: version check failed: %w\n%s", pkg.Name, versionErr, diagMsg)
 			}
 			return fmt.Errorf("%s: version check failed: %w", pkg.Name, versionErr)

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -846,7 +846,11 @@ func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg 
 			binPath = finalPath // fallback to finalPath if not in bin-dir
 		}
 		t.SetDescription("Verifying installed version")
-		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, binPath, pkg.VersionCommand, pkg.VersionRegex, pkg.Mode)
+		versionCheckMode := pkg.Mode
+		if pkg.Mode == "directory" && binPath != finalPath {
+			versionCheckMode = ""
+		}
+		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, binPath, pkg.VersionCommand, pkg.VersionRegex, versionCheckMode)
 		if versionErr != nil {
 			if diagMsg := pipeline.DiagnoseLibraryIssues(binPath, t); diagMsg != "" {
 				return fmt.Errorf("%s: version check failed: %w\n%s", pkg.Name, versionErr, diagMsg)

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -694,6 +694,19 @@ func (i *Installer) resolveAndValidateVersion(ctx context.Context, mgr manager.P
 
 	// Check if binary already exists with correct version (unless force flag is set)
 	if !i.options.Force {
+		// Skip existing-install check if the binary's architecture doesn't match the requested one
+		if i.options.ArchOverride != "" {
+			binaryName := name
+			if pkg.BinaryName != "" {
+				binaryName = pkg.BinaryName
+			}
+			binPath := filepath.Join(i.options.BinDir, binaryName)
+			if nativeArch := pipeline.DetectBinaryArch(binPath); nativeArch != "" && !archMatches(nativeArch, i.options.ArchOverride) {
+				t.Debugf("Existing %s is %s but %s requested, reinstalling", binaryName, nativeArch, i.options.ArchOverride)
+				return resolvedVersion, false, nil
+			}
+		}
+
 		if existingVersion := versionpkg.CheckExistingInstallation(t, name, pkg, resolvedVersion, i.options.BinDir, i.options.OSOverride); existingVersion != "" {
 			t.Infof("✓ %s@%s is already installed", name, resolvedVersion)
 			t.Success()
@@ -758,10 +771,10 @@ func (i *Installer) downloadPackage(ctx context.Context, name, resolvedVersion s
 	return downloadPath, nil
 }
 
-// executePostProcessing runs the post-processing pipeline if configured
+// executePostProcessing runs the post-processing pipeline if configured.
 func (i *Installer) executePostProcessing(pkg types.Package, workDir, targetPath string, t *task.Task) error {
 	if len(pkg.PostProcess) == 0 {
-		return nil // No post-processing needed
+		return nil
 	}
 
 	// Filter post-process commands by platform
@@ -782,14 +795,10 @@ func (i *Installer) executePostProcessing(pkg types.Package, workDir, targetPath
 
 	// Execute the CEL pipeline on the extracted contents
 	evaluator := pipeline.NewCELPipelineEvaluator(workDir, targetPath, i.options.TmpDir, t, i.options.Debug)
-	if err := evaluator.Execute(celPipeline); err != nil {
-		return err
-	}
-
-	return nil
+	return evaluator.Execute(celPipeline)
 }
 
-// finalizeInstallation makes the binary executable and reports success
+// finalizeInstallation makes the binary executable and reports success.
 func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg types.Package, t *task.Task) error {
 	// Make executable (skip for directories and when post-process was used)
 	if len(pkg.PostProcess) == 0 && pkg.Mode != "directory" {
@@ -824,6 +833,26 @@ func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg 
 		}
 	}
 
+	// Verify installed version matches expected
+	if pkg.VersionCommand != "" {
+		t.SetDescription("Verifying installed version")
+		installedVersion, versionErr := versionpkg.GetInstalledVersionWithMode(t, finalPath, pkg.VersionCommand, pkg.VersionRegex, pkg.Mode)
+		if versionErr != nil {
+			if diagMsg := pipeline.DiagnoseLibraryIssues(finalPath, t); diagMsg != "" {
+				return fmt.Errorf("%s: version check failed: %w\n%s", pkg.Name, versionErr, diagMsg)
+			}
+			return fmt.Errorf("%s: version check failed: %w", pkg.Name, versionErr)
+		}
+		status, _ := versionpkg.CompareVersions(installedVersion, resolvedVersion)
+		if status != types.CheckStatusOK && status != types.CheckStatusNewer {
+			return &VersionMismatchError{
+				Tool:     pkg.Name,
+				Expected: resolvedVersion,
+				Got:      installedVersion,
+			}
+		}
+	}
+
 	// Mark task successful only after all operations (including post-processing) complete
 	t.SetDescription(fmt.Sprintf("Successfully installed to %s", finalPath))
 	t.Success()
@@ -831,7 +860,7 @@ func (i *Installer) finalizeInstallation(resolvedVersion, finalPath string, pkg 
 	return nil
 }
 
-// handleArchiveInstallation processes an archive download (extraction, binary finding, post-processing)
+// handleArchiveInstallation processes an archive download (extraction, binary finding, post-processing).
 func (i *Installer) handleArchiveInstallation(downloadPath, name, resolvedVersion string, resolution *types.Resolution, pkg types.Package, t *task.Task) (string, error) {
 	// Auto-extract archive to working directory immediately after download
 	workDir := filepath.Join(i.options.TmpDir, fmt.Sprintf("deps-extract-%s-%s", name, resolvedVersion))
@@ -846,10 +875,10 @@ func (i *Installer) handleArchiveInstallation(downloadPath, name, resolvedVersio
 	cleanup.AddFile(downloadPath)
 	defer cleanup.GetCleanupFunc()()
 
-	var finalPath string
-
 	// Use resolution.Package since managers can modify the mode
 	resolvedPkg := resolution.Package
+
+	var finalPath string
 
 	// Handle directory mode installation
 	if resolvedPkg.Mode == "directory" {
@@ -871,36 +900,29 @@ func (i *Installer) handleArchiveInstallation(downloadPath, name, resolvedVersio
 	} else {
 		finalPath = filepath.Join(i.options.BinDir, name)
 
-		// Check if package has post-processing pipeline
-		if len(resolvedPkg.PostProcess) > 0 {
-			// Execute the CEL pipeline on the extracted contents
-			if err := i.executePostProcessing(resolvedPkg, workDir, finalPath, t); err != nil {
-				return "", err
-			}
+		if err := i.executePostProcessing(resolvedPkg, workDir, finalPath, t); err != nil {
+			return "", err
+		}
 
-			// Make executable after post-processing completes
-			if fileInfo, err := os.Stat(finalPath); err == nil && !fileInfo.IsDir() {
-				if err := os.Chmod(finalPath, 0755); err != nil {
-					return "", fmt.Errorf("failed to make binary executable: %w", err)
-				}
-			}
-
-		} else {
-			// Regular binary search in already extracted archive
+		// Find and copy the binary from the extract dir to finalPath.
+		// Always copy — if we reached this point, resolveAndValidateVersion
+		// already decided a (re)install is needed.
+		{
 			t.SetDescription("Searching for binary")
-
 			binaryPath, err := extract.FindBinaryInDir(workDir, resolution.BinaryPath, t)
 			if err != nil {
 				return "", fmt.Errorf("failed to find binary %s: %w", name, err)
 			}
-
 			utils.LogFileFound(t, binaryPath, "binary")
-
-			// Copy binary to final destination
 			t.SetDescription("Installing binary")
-
 			if err := utils.CopyFile(binaryPath, finalPath); err != nil {
 				return "", fmt.Errorf("failed to install binary: %w", err)
+			}
+		}
+
+		if fileInfo, err := os.Stat(finalPath); err == nil && !fileInfo.IsDir() {
+			if err := os.Chmod(finalPath, 0755); err != nil {
+				return "", fmt.Errorf("failed to make binary executable: %w", err)
 			}
 		}
 	}
@@ -1208,4 +1230,14 @@ func (i *Installer) downloadWithChecksum(url, dest, checksumURL string, resoluti
 
 	// Download without checksum verification (only reached in non-strict mode or when no checksum is configured)
 	return download.Download(url, dest, t, download.WithCacheDir(i.options.CacheDir))
+}
+
+// archMatches returns true if nativeArch (e.g. "x86_64", "arm64") corresponds
+// to goArch (e.g. "amd64", "arm64").
+func archMatches(nativeArch, goArch string) bool {
+	if nativeArch == goArch {
+		return true
+	}
+	return (nativeArch == "x86_64" && goArch == "amd64") ||
+		(nativeArch == "amd64" && goArch == "x86_64")
 }

--- a/pkg/manager/asset_filter.go
+++ b/pkg/manager/asset_filter.go
@@ -187,8 +187,13 @@ func filterByArch(assets []AssetInfo, arch string) ([]AssetInfo, error) {
 		}
 	}
 
-	// If no arch-specific files found, return all (might be universal binaries)
+	// If no arch-specific files found, check whether the remaining assets
+	// contain arch markers from other architectures. If they do, they are
+	// not universal binaries — they are simply the wrong architecture.
 	if len(filtered) == 0 {
+		if hasOtherArchMarkers(assets, arch) {
+			return nil, fmt.Errorf("no assets found matching architecture '%s'", arch)
+		}
 		return assets, nil
 	}
 
@@ -198,6 +203,30 @@ func filterByArch(assets []AssetInfo, arch string) ([]AssetInfo, error) {
 	}
 
 	return filtered, nil
+}
+
+// hasOtherArchMarkers returns true if any asset contains an arch alias
+// belonging to a different architecture than the requested one.
+func hasOtherArchMarkers(assets []AssetInfo, requestedArch string) bool {
+	allArchAliases := map[string][]string{
+		"amd64": {"amd64", "x86_64", "x64", "x86-64", "x86", "i386", "i686"},
+		"arm64": {"arm64", "aarch64"},
+		"arm":   {"armv7", "armv7l"},
+	}
+	for _, asset := range assets {
+		nameLower := strings.ToLower(asset.Name)
+		for archKey, aliases := range allArchAliases {
+			if archKey == requestedArch {
+				continue
+			}
+			for _, alias := range aliases {
+				if strings.Contains(nameLower, alias) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // preferArm64Assets filters to prefer arm64/aarch64 assets over arm-only assets.

--- a/pkg/manager/asset_filter_test.go
+++ b/pkg/manager/asset_filter_test.go
@@ -305,7 +305,23 @@ var _ = Describe("Asset Filtering", func() {
 				expected: []string{"universal-binary"},
 			},
 			{
-				name: "should prefer arm64 over arm when both exist",
+				name: "should not return wrong-arch asset as universal (aarch64 when amd64 requested)",
+			assets: []string{
+				"postgrest-v14.6-macos-aarch64.tar.xz",
+			},
+			arch:    "amd64",
+			wantErr: true,
+		},
+		{
+			name: "should not return wrong-arch asset as universal (x86_64 when arm64 requested)",
+			assets: []string{
+				"tool-macos-x86_64.tar.gz",
+			},
+			arch:    "arm64",
+			wantErr: true,
+		},
+		{
+			name: "should prefer arm64 over arm when both exist",
 				assets: []string{
 					"yq_linux_arm.tar.gz",
 					"yq_linux_arm64.tar.gz",
@@ -470,6 +486,19 @@ var _ = Describe("Asset Filtering", func() {
 				os:       "linux",
 				arch:     "amd64",
 				expected: []string{"kubectl", "kubectl.exe"},
+			},
+			{
+				name: "should reject wrong-arch asset after OS filtering (postgrest aarch64 for amd64)",
+				assets: []string{
+					"postgrest-v14.6-freebsd-x86-64.tar.xz",
+					"postgrest-v14.6-linux-static-x86-64.tar.xz",
+					"postgrest-v14.6-macos-aarch64.tar.xz",
+					"postgrest-v14.6-ubuntu-aarch64.tar.xz",
+					"postgrest-v14.6-windows-x86-64.zip",
+				},
+				os:      "darwin",
+				arch:    "amd64",
+				wantErr: true,
 			},
 		}
 

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -332,6 +332,17 @@ func (m *GitHubReleaseManager) buildResolutionFromRelease(pkg types.Package, rel
 		}
 	}
 
+	// Apply version_fallback if configured
+	if pkg.VersionFallback != "" {
+		fallbackVer, fallbackTag, fbErr := versionpkg.EvaluateVersionFallback(pkg.VersionFallback, version, tagName, plat.OS, plat.Arch)
+		if fbErr == nil {
+			version = fallbackVer
+			tagName = fallbackTag
+		} else {
+			logger.Warnf("Failed to evaluate version_fallback for %s: %v", pkg.Name, fbErr)
+		}
+	}
+
 	// Get the asset pattern for this platform
 	assetPattern, patternErr := manager.ResolveAssetPattern(pkg.AssetPatterns, plat, pkg.Name)
 	if patternErr != nil {
@@ -475,6 +486,17 @@ func (m *GitHubReleaseManager) resolveViaGoGitHub(ctx context.Context, pkg types
 		versionForTemplate = versionpkg.Normalize(tagName)
 	} else {
 		versionForTemplate = versionpkg.Normalize(version)
+	}
+
+	// Apply version_fallback if configured
+	if pkg.VersionFallback != "" {
+		fallbackVer, fallbackTag, fbErr := versionpkg.EvaluateVersionFallback(pkg.VersionFallback, versionForTemplate, tagName, plat.OS, plat.Arch)
+		if fbErr == nil {
+			versionForTemplate = fallbackVer
+			tagName = fallbackTag
+		} else {
+			logger.Warnf("Failed to evaluate version_fallback for %s: %v", pkg.Name, fbErr)
+		}
 	}
 
 	// Template the asset pattern

--- a/pkg/manager/github/github_tags.go
+++ b/pkg/manager/github/github_tags.go
@@ -409,18 +409,18 @@ func (m *GitHubTagsManager) enhanceRateLimitError(ctx context.Context, originalE
 	// Build compact single-line message
 	msg.WriteString(". GitHub API rate limit")
 	if total > 0 {
-		msg.WriteString(fmt.Sprintf(": %d/%d remaining", remaining, total))
+		fmt.Fprintf(&msg, ": %d/%d remaining", remaining, total)
 	} else {
 		msg.WriteString(" exceeded")
 	}
 
 	if resetTime != nil {
 		timeUntilReset := time.Until(*resetTime)
-		msg.WriteString(fmt.Sprintf(", resets in %s", formatDuration(timeUntilReset)))
+		fmt.Fprintf(&msg, ", resets in %s", formatDuration(timeUntilReset))
 	}
 
 	if status.TokenSource != "" {
-		msg.WriteString(fmt.Sprintf(" (using %s)", status.TokenSource))
+		fmt.Fprintf(&msg, " (using %s)", status.TokenSource)
 	} else {
 		msg.WriteString(". Set GITHUB_TOKEN for 5000/hour limit")
 	}

--- a/pkg/manager/github/github_tags.go
+++ b/pkg/manager/github/github_tags.go
@@ -17,7 +17,7 @@ import (
 	"github.com/flanksource/deps/pkg/platform"
 	depstemplate "github.com/flanksource/deps/pkg/template"
 	"github.com/flanksource/deps/pkg/types"
-	"github.com/flanksource/deps/pkg/version"
+	versionpkg "github.com/flanksource/deps/pkg/version"
 	"github.com/google/go-github/v57/github"
 )
 
@@ -67,7 +67,7 @@ func (m *GitHubTagsManager) DiscoverVersions(ctx context.Context, pkg types.Pack
 
 	// Apply version expression filtering if specified
 	if pkg.VersionExpr != "" {
-		filteredVersions, err := version.ApplyVersionExpr(versions, pkg.VersionExpr)
+		filteredVersions, err := versionpkg.ApplyVersionExpr(versions, pkg.VersionExpr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply version_expr for %s: %w", pkg.Name, err)
 		}
@@ -76,10 +76,10 @@ func (m *GitHubTagsManager) DiscoverVersions(ctx context.Context, pkg types.Pack
 	}
 
 	// Filter out versions that are not valid semantic versions after transformation
-	versions = version.FilterToValidSemver(versions)
+	versions = versionpkg.FilterToValidSemver(versions)
 
 	// Re-sort by transformed version (needed after version_expr transforms tags)
-	version.SortVersions(versions)
+	versionpkg.SortVersions(versions)
 
 	// Apply limit if specified
 	if limit > 0 && len(versions) > limit {
@@ -106,7 +106,7 @@ func (m *GitHubTagsManager) discoverVersionsViaREST(ctx context.Context, owner, 
 
 	var versions []types.Version
 	for _, tag := range tags {
-		normalizedVersion := version.Normalize(tag.Name)
+		normalizedVersion := versionpkg.Normalize(tag.Name)
 		v := types.ParseVersion(normalizedVersion, tag.Name)
 		if tag.Commit != nil {
 			v.SHA = tag.Commit.SHA
@@ -150,6 +150,19 @@ func (m *GitHubTagsManager) Resolve(ctx context.Context, pkg types.Package, vers
 		return nil, err
 	}
 
+	// Apply version_fallback if configured
+	resolvedVersion := version
+	resolvedTag := tag.Name
+	if pkg.VersionFallback != "" {
+		fallbackVer, fallbackTag, fbErr := versionpkg.EvaluateVersionFallback(pkg.VersionFallback, version, tag.Name, plat.OS, plat.Arch)
+		if fbErr == nil {
+			resolvedVersion = fallbackVer
+			resolvedTag = fallbackTag
+		} else {
+			logger.Warnf("Failed to evaluate version_fallback for %s: %v", pkg.Name, fbErr)
+		}
+	}
+
 	// Get the asset pattern for this platform or use fallback
 	assetPattern := ""
 
@@ -171,13 +184,13 @@ func (m *GitHubTagsManager) Resolve(ctx context.Context, pkg types.Package, vers
 		assetPattern = "{{.name}}-{{.os}}-{{.arch}}"
 	}
 
-	normalizedVersion := depstemplate.NormalizeVersion(version)
+	normalizedVersion := depstemplate.NormalizeVersion(resolvedVersion)
 
 	// Template the asset pattern
 	templatedPattern, err := m.templateString(assetPattern, map[string]string{
 		"name":    pkg.Name,
 		"version": normalizedVersion,
-		"tag":     tag.Name,
+		"tag":     resolvedTag,
 		"os":      plat.OS,
 		"arch":    plat.Arch,
 	})
@@ -192,7 +205,7 @@ func (m *GitHubTagsManager) Resolve(ctx context.Context, pkg types.Package, vers
 	downloadURL, err := m.templateString(urlTemplate, map[string]string{
 		"name":    pkg.Name,
 		"version": normalizedVersion,
-		"tag":     tag.Name,
+		"tag":     resolvedTag,
 		"os":      plat.OS,
 		"arch":    plat.Arch,
 		"asset":   templatedPattern,
@@ -257,7 +270,7 @@ func (m *GitHubTagsManager) Resolve(ctx context.Context, pkg types.Package, vers
 
 	resolution := &types.Resolution{
 		Package:     pkg,
-		Version:     version,
+		Version:     resolvedVersion,
 		Platform:    plat,
 		DownloadURL: finalDownloadURL,
 		IsArchive:   isArchive,
@@ -281,8 +294,8 @@ func (m *GitHubTagsManager) Resolve(ctx context.Context, pkg types.Package, vers
 			"os":      plat.OS,
 			"arch":    plat.Arch,
 			"name":    pkg.Name,
-			"version": depstemplate.NormalizeVersion(version),
-			"tag":     tag.Name,
+			"version": depstemplate.NormalizeVersion(resolvedVersion),
+			"tag":     resolvedTag,
 		}
 
 		evaluatedChecksumFile, err := depstemplate.EvaluateCELOrTemplate(checksumFile, data)
@@ -292,7 +305,7 @@ func (m *GitHubTagsManager) Resolve(ctx context.Context, pkg types.Package, vers
 
 		// Only proceed if we have a non-empty checksum file after evaluation
 		if checksumFile != "" {
-			checksumURL, err := m.templateChecksumURL(checksumFile, templatedPattern, version, tag.Name, plat)
+			checksumURL, err := m.templateChecksumURL(checksumFile, templatedPattern, resolvedVersion, resolvedTag, plat)
 			if err == nil && checksumURL != "" {
 				resolution.ChecksumURL = checksumURL
 			}
@@ -591,7 +604,7 @@ func (m *GitHubTagsManager) findTagByVersion(ctx context.Context, pkg types.Pack
 	}
 
 	// Try version normalization match (with version_expr transformation)
-	normalizedTarget := version.Normalize(targetVersion)
+	normalizedTarget := versionpkg.Normalize(targetVersion)
 	for _, tag := range tags {
 		tagName := tag.Name
 		transformedTag := tagName
@@ -602,7 +615,7 @@ func (m *GitHubTagsManager) findTagByVersion(ctx context.Context, pkg types.Pack
 			}
 		}
 
-		if version.Normalize(transformedTag) == normalizedTarget {
+		if versionpkg.Normalize(transformedTag) == normalizedTarget {
 			sha := ""
 			if tag.Commit != nil {
 				sha = tag.Commit.SHA
@@ -634,7 +647,7 @@ func ApplyVersionExprToSingleTag(tag, versionExpr string) (string, error) {
 	}
 
 	// Apply the version expression
-	result, err := version.ApplyVersionExpr([]types.Version{testVersion}, versionExpr)
+	result, err := versionpkg.ApplyVersionExpr([]types.Version{testVersion}, versionExpr)
 	if err != nil {
 		return "", fmt.Errorf("failed to apply version_expr to tag %s: %w", tag, err)
 	}

--- a/pkg/manager/recommendations.go
+++ b/pkg/manager/recommendations.go
@@ -22,8 +22,8 @@ func EnhanceErrorWithVersions(packageName, requestedVersion string, availableVer
 
 	// Build enhanced error message
 	var errorMsg strings.Builder
-	errorMsg.WriteString(fmt.Sprintf("Version %s not found for %s\n\n", requestedVersion, packageName))
-	errorMsg.WriteString(fmt.Sprintf("Available versions (%d total):\n", len(availableVersions)))
+	fmt.Fprintf(&errorMsg, "Version %s not found for %s\n\n", requestedVersion, packageName)
+	fmt.Fprintf(&errorMsg, "Available versions (%d total):\n", len(availableVersions))
 
 	// Show latest versions (up to 10)
 	maxVersions := 10
@@ -37,16 +37,16 @@ func EnhanceErrorWithVersions(packageName, requestedVersion string, availableVer
 		if v.Prerelease {
 			suffix += " (prerelease)"
 		}
-		errorMsg.WriteString(fmt.Sprintf("  %s%s\n", v.Tag, suffix))
+		fmt.Fprintf(&errorMsg, "  %s%s\n", v.Tag, suffix)
 	}
 
 	if len(availableVersions) > maxVersions {
-		errorMsg.WriteString(fmt.Sprintf("  ... and %d more versions\n", len(availableVersions)-maxVersions))
+		fmt.Fprintf(&errorMsg, "  ... and %d more versions\n", len(availableVersions)-maxVersions)
 	}
 
 	// Suggest closest match
 	if suggestion := SuggestClosestVersion(requestedVersion, availableVersions); suggestion != "" {
-		errorMsg.WriteString(fmt.Sprintf("\nDid you mean: %s?", suggestion))
+		fmt.Fprintf(&errorMsg, "\nDid you mean: %s?", suggestion)
 	}
 
 	return fmt.Errorf("%s", errorMsg.String())
@@ -196,8 +196,8 @@ func EnhanceAssetNotFoundError(packageName, assetPattern, platform string, avail
 
 	// Build enhanced error message
 	var errorMsg strings.Builder
-	errorMsg.WriteString(fmt.Sprintf("Asset not found: %s for %s in package %s\n\n", assetPattern, platform, packageName))
-	errorMsg.WriteString(fmt.Sprintf("Available assets (%d total):\n", len(assetsWithDist)))
+	fmt.Fprintf(&errorMsg, "Asset not found: %s for %s in package %s\n\n", assetPattern, platform, packageName)
+	fmt.Fprintf(&errorMsg, "Available assets (%d total):\n", len(assetsWithDist))
 
 	// Show up to 20 assets (most relevant ones)
 	maxAssets := 20
@@ -207,15 +207,15 @@ func EnhanceAssetNotFoundError(packageName, assetPattern, platform string, avail
 	}
 
 	for _, asset := range displayAssets {
-		errorMsg.WriteString(fmt.Sprintf("  %s\n", asset.name))
+		fmt.Fprintf(&errorMsg, "  %s\n", asset.name)
 	}
 
 	if len(assetsWithDist) > maxAssets {
-		errorMsg.WriteString(fmt.Sprintf("  ... and %d more assets\n", len(assetsWithDist)-maxAssets))
+		fmt.Fprintf(&errorMsg, "  ... and %d more assets\n", len(assetsWithDist)-maxAssets)
 	}
 
 	// Show the pattern that was searched for
-	errorMsg.WriteString(fmt.Sprintf("\nSearched for pattern: %s", assetPattern))
+	fmt.Fprintf(&errorMsg, "\nSearched for pattern: %s", assetPattern)
 
 	// Suggest closest match (first sorted asset)
 	sortedAssetNames := make([]string, len(assetsWithDist))
@@ -223,7 +223,7 @@ func EnhanceAssetNotFoundError(packageName, assetPattern, platform string, avail
 		sortedAssetNames[i] = a.name
 	}
 	if suggestion := SuggestClosestAsset(assetPattern, sortedAssetNames); suggestion != "" {
-		errorMsg.WriteString(fmt.Sprintf("\nDid you mean: %s?", suggestion))
+		fmt.Fprintf(&errorMsg, "\nDid you mean: %s?", suggestion)
 	}
 
 	return fmt.Errorf("%s: %w", errorMsg.String(), originalErr)

--- a/pkg/pipeline/cel.go
+++ b/pkg/pipeline/cel.go
@@ -698,7 +698,7 @@ func (f *functions) deleteFiles(matches []string, context string) ([]string, err
 	}
 
 	if len(failed) > 0 {
-		f.ctx.LogError(fmt.Sprintf("Failed to delete %d items: %v", len(failed), failed))
+		f.ctx.LogError(fmt.Sprintf("Failed to delete %d items (%s): %v", len(failed), context, failed))
 	}
 
 	if totalSize > 0 {

--- a/pkg/pipeline/context.go
+++ b/pkg/pipeline/context.go
@@ -49,6 +49,20 @@ func (ctx *PipelineContext) LogDebug(message string) {
 	}
 }
 
+// LogTrace logs a trace message (V4) if task context is available
+func (ctx *PipelineContext) LogTrace(message string) {
+	if ctx.Task != nil {
+		ctx.Task.V(4).Infof("%s", message)
+	}
+}
+
+// LogWarn logs a warning message if task context is available
+func (ctx *PipelineContext) LogWarn(message string) {
+	if ctx.Task != nil {
+		ctx.Task.Warnf("%s", message)
+	}
+}
+
 // LogError logs an error message if task context is available
 func (ctx *PipelineContext) LogError(message string) {
 	if ctx.Task != nil {

--- a/pkg/pipeline/fix_dylibs.go
+++ b/pkg/pipeline/fix_dylibs.go
@@ -1,0 +1,105 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/flanksource/clicky/task"
+)
+
+// DylibRef represents a dynamic library reference found in a binary.
+type DylibRef struct {
+	Path  string
+	Found bool
+}
+
+var searchDirs = []string{
+	"/opt/homebrew/opt/*/lib",
+	"/opt/homebrew/lib",
+	"/opt/homebrew/Cellar/*/*/lib",
+	"/usr/local/opt/*/lib",
+	"/usr/local/lib",
+	"/usr/local/Cellar/*/*/lib",
+	"/usr/local/Cellar/*/*/lib/postgresql",
+	"/usr/lib",
+	"/usr/lib/x86_64-linux-gnu",
+	"/usr/lib/aarch64-linux-gnu",
+	"/usr/local/lib/postgresql@*",
+}
+
+// findLibrary searches standard directories for a library matching basename.
+// If targetArch is non-empty, only libraries matching that architecture are returned.
+// When no compatible library is found, mismatchPath/mismatchArch report the first
+// candidate that was skipped due to an architecture mismatch.
+func findLibrary(basename, targetArch string) (path, mismatchPath, mismatchArch string) {
+	for _, pattern := range searchDirs {
+		var dirs []string
+		if strings.ContainsAny(pattern, "*?[") {
+			expanded, _ := filepath.Glob(pattern)
+			dirs = expanded
+		} else {
+			dirs = []string{pattern}
+		}
+		for _, dir := range dirs {
+			matches, _ := filepath.Glob(filepath.Join(dir, basename))
+			for _, m := range matches {
+				if _, err := os.Stat(m); err != nil {
+					continue
+				}
+				if targetArch != "" {
+					libArch := detectArch(m)
+					if libArch != "" && libArch != targetArch {
+						if mismatchPath == "" {
+							mismatchPath = m
+							mismatchArch = libArch
+						}
+						continue
+					}
+				}
+				return m, "", ""
+			}
+		}
+	}
+	return "", mismatchPath, mismatchArch
+}
+
+// DetectBinaryArch returns the native architecture string for a binary
+// (e.g. "arm64", "x86_64" on macOS; empty on unsupported platforms).
+func DetectBinaryArch(path string) string {
+	return detectArch(path)
+}
+
+// DiagnoseLibraryIssues detects broken dynamic library references on the installed
+// binary and checks for architecture mismatches. Returns a human-readable diagnostic
+// string with suggestions (e.g. --arch <alt>), or "" if no issues found.
+func DiagnoseLibraryIssues(binaryPath string, t *task.Task) string {
+	binaryArch := detectArch(binaryPath)
+	refs, err := detectBrokenDylibs(binaryPath, binaryArch)
+	if err != nil || len(refs) == 0 {
+		return ""
+	}
+
+	var issues []string
+	for _, ref := range refs {
+		if ref.Found {
+			continue
+		}
+		basename := filepath.Base(ref.Path)
+		_, mismatchPath, mismatchArch := findLibrary(basename, binaryArch)
+		if mismatchPath != "" {
+			issues = append(issues, fmt.Sprintf(
+				"  %s: found at %s but it is %s (binary is %s)\n  → try: deps install <pkg> --arch %s",
+				basename, mismatchPath, mismatchArch, binaryArch, machoArchToGoArch(mismatchArch)))
+		} else {
+			issues = append(issues, fmt.Sprintf(
+				"  %s: not found on system (expected at %s)", basename, ref.Path))
+		}
+	}
+
+	if len(issues) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("Library issues detected:\n%s", strings.Join(issues, "\n"))
+}

--- a/pkg/pipeline/fix_dylibs_darwin.go
+++ b/pkg/pipeline/fix_dylibs_darwin.go
@@ -1,0 +1,68 @@
+//go:build darwin
+
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func detectBrokenDylibs(binaryPath, binaryArch string) ([]DylibRef, error) {
+	out, err := exec.Command("otool", "-L", binaryPath).Output()
+	if err != nil {
+		return nil, fmt.Errorf("otool -L failed: %w", err)
+	}
+	return parseOtoolOutput(string(out), binaryArch), nil
+}
+
+func parseOtoolOutput(output, binaryArch string) []DylibRef {
+	var refs []DylibRef
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, "(compatibility") {
+			continue
+		}
+		// Format: "/path/to/lib.dylib (compatibility version X, current version Y)"
+		parenIdx := strings.Index(line, " (compatibility")
+		if parenIdx < 0 {
+			continue
+		}
+		path := strings.TrimSpace(line[:parenIdx])
+		if path == "" || strings.HasPrefix(path, "@") || strings.HasPrefix(path, "/usr/lib/lib") || strings.HasPrefix(path, "/System/") {
+			continue
+		}
+		_, err := os.Stat(path)
+		found := err == nil
+		if found && binaryArch != "" {
+			if libArch := detectArch(path); libArch != "" && libArch != binaryArch {
+				found = false
+			}
+		}
+		refs = append(refs, DylibRef{Path: path, Found: found})
+	}
+	return refs
+}
+
+func machoArchToGoArch(arch string) string {
+	if arch == "x86_64" {
+		return "amd64"
+	}
+	return arch
+}
+
+// detectArch returns the Mach-O architecture string (e.g. "arm64", "x86_64") for a binary.
+func detectArch(path string) string {
+	out, err := exec.Command("file", path).Output()
+	if err != nil {
+		return ""
+	}
+	s := string(out)
+	for _, arch := range []string{"arm64", "x86_64"} {
+		if strings.Contains(s, arch) {
+			return arch
+		}
+	}
+	return ""
+}

--- a/pkg/pipeline/fix_dylibs_linux.go
+++ b/pkg/pipeline/fix_dylibs_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package pipeline
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func detectBrokenDylibs(binaryPath, _ string) ([]DylibRef, error) {
+	out, err := exec.Command("ldd", binaryPath).Output()
+	if err != nil {
+		return nil, fmt.Errorf("ldd failed: %w", err)
+	}
+	return parseLddOutput(string(out)), nil
+}
+
+func parseLddOutput(output string) []DylibRef {
+	var refs []DylibRef
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "=> not found") {
+			parts := strings.SplitN(line, " =>", 2)
+			refs = append(refs, DylibRef{Path: strings.TrimSpace(parts[0]), Found: false})
+		}
+	}
+	return refs
+}
+
+func machoArchToGoArch(arch string) string {
+	return arch
+}
+
+// detectArch is a no-op on linux — ELF shared libs don't have the same arch mismatch issue
+// because the linker resolves by matching ELF class/machine type automatically.
+func detectArch(path string) string {
+	return ""
+}

--- a/pkg/pipeline/fix_dylibs_other.go
+++ b/pkg/pipeline/fix_dylibs_other.go
@@ -1,0 +1,15 @@
+//go:build !darwin && !linux
+
+package pipeline
+
+func detectBrokenDylibs(binaryPath, _ string) ([]DylibRef, error) {
+	return nil, nil
+}
+
+func machoArchToGoArch(arch string) string {
+	return arch
+}
+
+func detectArch(path string) string {
+	return ""
+}

--- a/pkg/pipeline/fix_dylibs_test.go
+++ b/pkg/pipeline/fix_dylibs_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package pipeline
 
 import (

--- a/pkg/pipeline/fix_dylibs_test.go
+++ b/pkg/pipeline/fix_dylibs_test.go
@@ -1,0 +1,150 @@
+package pipeline
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestParseOtoolOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected []DylibRef
+	}{
+		{
+			name: "typical postgrest output with broken ref",
+			output: `/tmp/postgrest:
+	/opt/homebrew/opt/libpq/lib/libpq.5.dylib (compatibility version 5.0.0, current version 5.17.0)
+	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
+	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2503.1.0)
+`,
+			expected: []DylibRef{
+				{Path: "/opt/homebrew/opt/libpq/lib/libpq.5.dylib", Found: false},
+			},
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			expected: nil,
+		},
+		{
+			name: "skip @rpath references",
+			output: `test:
+	@rpath/libfoo.dylib (compatibility version 1.0.0, current version 1.0.0)
+	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
+`,
+			expected: nil,
+		},
+		{
+			name: "multiple broken refs",
+			output: `binary:
+	/nonexistent/path/libpq.5.dylib (compatibility version 5.0.0, current version 5.17.0)
+	/also/missing/libssl.3.dylib (compatibility version 3.0.0, current version 3.1.0)
+	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
+`,
+			expected: []DylibRef{
+				{Path: "/nonexistent/path/libpq.5.dylib", Found: false},
+				{Path: "/also/missing/libssl.3.dylib", Found: false},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseOtoolOutput(tc.output, "")
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %d refs, got %d: %+v", len(tc.expected), len(result), result)
+			}
+			for i, ref := range result {
+				if ref.Path != tc.expected[i].Path {
+					t.Errorf("ref[%d].Path = %q, want %q", i, ref.Path, tc.expected[i].Path)
+				}
+				if ref.Found != tc.expected[i].Found {
+					t.Errorf("ref[%d].Found = %v, want %v", i, ref.Found, tc.expected[i].Found)
+				}
+			}
+		})
+	}
+}
+
+func TestFindLibrary(t *testing.T) {
+	result, _, _ := findLibrary("libpq.5.dylib", "")
+	if result == "" {
+		t.Skip("libpq.5.dylib not found on this system")
+	}
+	t.Logf("found libpq (any arch) at: %s", result)
+}
+
+func TestFindLibraryWithArch(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("architecture filtering only applies to darwin")
+	}
+	arch := map[string]string{"arm64": "arm64", "amd64": "x86_64"}[runtime.GOARCH]
+	if arch == "" {
+		t.Skipf("unknown GOARCH: %s", runtime.GOARCH)
+	}
+
+	result, _, _ := findLibrary("libpq.5.dylib", arch)
+	if result == "" {
+		t.Skipf("no %s libpq.5.dylib found on this system", arch)
+	}
+	t.Logf("found %s libpq at: %s", arch, result)
+
+	// Verify the library is actually the right architecture
+	libArch := detectArch(result)
+	if libArch != arch {
+		t.Errorf("findLibrary returned %s with arch %q, want %q", result, libArch, arch)
+	}
+}
+
+func TestFindLibraryArchMismatch(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("architecture mismatch detection only applies to darwin")
+	}
+	// Request the opposite architecture to trigger a mismatch
+	oppositeArch := map[string]string{"arm64": "x86_64", "amd64": "arm64"}[runtime.GOARCH]
+	if oppositeArch == "" {
+		t.Skipf("unknown GOARCH: %s", runtime.GOARCH)
+	}
+
+	path, mismatchPath, mismatchArch := findLibrary("libpq.5.dylib", oppositeArch)
+	if path != "" {
+		t.Skipf("found a %s libpq — no mismatch to test", oppositeArch)
+	}
+	if mismatchPath == "" {
+		t.Skip("no libpq.5.dylib found at all on this system")
+	}
+	t.Logf("mismatch: found %s at %s (wanted %s)", mismatchArch, mismatchPath, oppositeArch)
+	if mismatchArch == oppositeArch {
+		t.Errorf("mismatchArch should differ from requested arch %s", oppositeArch)
+	}
+}
+
+func TestMachoArchToGoArch(t *testing.T) {
+	tests := []struct{ input, want string }{
+		{"x86_64", "amd64"},
+		{"arm64", "arm64"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := machoArchToGoArch(tc.input); got != tc.want {
+			t.Errorf("machoArchToGoArch(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestDetectArch(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("detectArch uses macOS file command")
+	}
+	// Use a known existing library instead of system cache dylibs
+	lib, _, _ := findLibrary("libpq.5.dylib", "")
+	if lib == "" {
+		t.Skip("no libpq.5.dylib found to test arch detection")
+	}
+	arch := detectArch(lib)
+	t.Logf("%s arch: %s", lib, arch)
+	if arch == "" {
+		t.Errorf("expected non-empty arch for %s", lib)
+	}
+}

--- a/pkg/runtime/detector.go
+++ b/pkg/runtime/detector.go
@@ -188,10 +188,15 @@ func (d *runtimeDetector) installRuntime(constraint string) (*runtimeInfo, error
 		d.task.V(3).Infof("Installing %s version %s via deps", d.language, versionToInstall)
 	}
 
-	// Get global config
 	depsConfig := config.GetGlobalRegistry()
+	if depsConfig == nil {
+		return nil, fmt.Errorf("failed to install %s: global registry is nil", d.language)
+	}
 
-	// Create installer
+	if _, hasPkg := depsConfig.Registry[d.language]; !hasPkg {
+		return nil, fmt.Errorf("failed to install %s: not found in registry (%d packages loaded)", d.language, len(depsConfig.Registry))
+	}
+
 	inst := installer.NewWithConfig(depsConfig)
 
 	// Ensure we have a task for installation

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -170,7 +170,7 @@ func TestRunJava(t *testing.T) {
 func TestRunPowershell(t *testing.T) {
 	t.Run("execute simple PowerShell script", func(t *testing.T) {
 		result, err := deps.RunPowershell("testdata/test_powershell_runtime.ps1", deps.RunOptions{
-			Timeout: 10 * time.Second,
+			Timeout: 120 * time.Second,
 			Version: "7.4.6",
 			Env: map[string]string{
 				"TEST_API_KEY": "test_value_abc",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -59,6 +59,8 @@ type Package struct {
 	VersionRegex string `json:"version_regex,omitempty" yaml:"version_regex,omitempty"`
 	// VersionExpr is a CEL expression to filter and transform discovered versions
 	VersionExpr string `json:"version_expr,omitempty" yaml:"version_expr,omitempty"`
+	// VersionFallback is a CEL expression to transform the resolved version before URL templating (e.g., strip patch for envtest)
+	VersionFallback string `json:"version_fallback,omitempty" yaml:"version_fallback,omitempty"`
 	// BinaryName specifies a custom name for the binary (defaults to package name)
 	BinaryName string `json:"binary_name,omitempty" yaml:"binary_name,omitempty"`
 	// BinaryPath is the path within an archive to the binary (supports CEL expressions)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -61,6 +61,8 @@ type Package struct {
 	VersionExpr string `json:"version_expr,omitempty" yaml:"version_expr,omitempty"`
 	// VersionFallback is a CEL expression to transform the resolved version before URL templating (e.g., strip patch for envtest)
 	VersionFallback string `json:"version_fallback,omitempty" yaml:"version_fallback,omitempty"`
+	// VerifyExpr is a CEL expression for custom post-install version verification (context: installed, expected, output, os, arch)
+	VerifyExpr string `json:"verify_expr,omitempty" yaml:"verify_expr,omitempty"`
 	// BinaryName specifies a custom name for the binary (defaults to package name)
 	BinaryName string `json:"binary_name,omitempty" yaml:"binary_name,omitempty"`
 	// BinaryPath is the path within an archive to the binary (supports CEL expressions)

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -85,9 +85,10 @@ func resolveBinaryPath(tool string, pkg types.Package, binDir string, osOverride
 	}
 
 	// For directory mode packages with symlinks, use the symlink for version checking
-	if pkg.Mode == "directory" && len(pkg.Symlinks) > 0 && pkg.VersionCommand != "" {
+	// Skip shell-wrapped commands (bash -c, sh -c) — they must run in directory mode
+	if pkg.Mode == "directory" && len(pkg.Symlinks) > 0 && pkg.VersionCommand != "" && !ContainsShellOperators(pkg.VersionCommand) {
 		cmdParts := strings.Fields(pkg.VersionCommand)
-		if len(cmdParts) > 0 {
+		if len(cmdParts) > 0 && cmdParts[0] != "bash" && cmdParts[0] != "sh" {
 			symlinkName := filepath.Base(cmdParts[0])
 			binaryPath := filepath.Join(binDir, symlinkName)
 

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -188,7 +188,12 @@ func GetInstalledVersionWithMode(t *task.Task, binaryPath, versionCommand, versi
 		// Run with timeout
 		result := p.WithTimeout(timeout).Run()
 		if result.Err != nil {
-			lastErr = result.Err
+			stderr := strings.TrimSpace(result.GetStderr())
+			if stderr != "" {
+				lastErr = fmt.Errorf("%w: %s", result.Err, stderr)
+			} else {
+				lastErr = result.Err
+			}
 			continue
 		}
 
@@ -202,7 +207,7 @@ func GetInstalledVersionWithMode(t *task.Task, binaryPath, versionCommand, versi
 
 	if lastErr != nil {
 		t.V(3).Infof("All version commands failed for %s", utils.LogPath(binaryPath))
-		return "", fmt.Errorf("all version commands failed, last error: %v", lastErr)
+		return "", lastErr
 	}
 
 	version, err := parseVersionOutput(string(output), versionPattern)
@@ -272,7 +277,7 @@ func CheckBinaryVersion(t *task.Task, tool string, pkg types.Package, binDir str
 		compareVersion = requestedVersion
 	}
 
-	status, err := compareVersions(installedVersion, compareVersion)
+	status, err := CompareVersions(installedVersion, compareVersion)
 	if err != nil {
 		result.Status = types.CheckStatusError
 		result.Error = err.Error()

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -131,20 +131,21 @@ func resolveBinaryPath(tool string, pkg types.Package, binDir string, osOverride
 	}, nil
 }
 
-// GetInstalledVersion executes a binary with its version command and extracts the version
-func GetInstalledVersion(t *task.Task, binaryPath, versionCommand, versionPattern string) (string, error) {
+// GetInstalledVersion executes a binary with its version command and extracts the version.
+// Returns (parsedVersion, rawOutput, error).
+func GetInstalledVersion(t *task.Task, binaryPath, versionCommand, versionPattern string) (string, string, error) {
 	return GetInstalledVersionWithMode(t, binaryPath, versionCommand, versionPattern, "")
 }
 
 // GetInstalledVersionWithMode executes a binary with its version command and extracts the version,
-// supporting directory mode packages
-func GetInstalledVersionWithMode(t *task.Task, binaryPath, versionCommand, versionPattern, mode string) (string, error) {
+// supporting directory mode packages. Returns (parsedVersion, rawOutput, error).
+func GetInstalledVersionWithMode(t *task.Task, binaryPath, versionCommand, versionPattern, mode string) (string, string, error) {
 	if binaryPath == "" {
-		return "", fmt.Errorf("binary path is empty")
+		return "", "", fmt.Errorf("binary path is empty")
 	}
 
 	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("binary not found: %s", binaryPath)
+		return "", "", fmt.Errorf("binary not found: %s", binaryPath)
 	}
 
 	wasCustomCommand := versionCommand != ""
@@ -208,17 +209,19 @@ func GetInstalledVersionWithMode(t *task.Task, binaryPath, versionCommand, versi
 
 	if lastErr != nil {
 		t.V(3).Infof("All version commands failed for %s", utils.LogPath(binaryPath))
-		return "", lastErr
+		return "", "", lastErr
 	}
 
-	version, err := parseVersionOutput(string(output), versionPattern)
+	rawOutput := string(output)
+	version, err := parseVersionOutput(rawOutput, versionPattern)
 	if err != nil {
-		return "", err
+		return "", rawOutput, err
 	}
 
 	t.V(3).Infof("Successfully extracted version: %s", version)
-	return version, nil
+	return version, rawOutput, nil
 }
+
 
 // CheckBinaryVersion checks the version of a binary against expected versions
 func CheckBinaryVersion(t *task.Task, tool string, pkg types.Package, binDir string, expectedVersion, requestedVersion string) types.CheckResult {
@@ -255,7 +258,7 @@ func CheckBinaryVersion(t *task.Task, tool string, pkg types.Package, binDir str
 	}
 
 	// Get installed version
-	installedVersion, err := GetInstalledVersionWithMode(t, pathInfo.BinaryPath, pathInfo.VersionCommand, pkg.VersionRegex, pathInfo.Mode)
+	installedVersion, rawOutput, err := GetInstalledVersionWithMode(t, pathInfo.BinaryPath, pathInfo.VersionCommand, pkg.VersionRegex, pathInfo.Mode)
 	if err != nil {
 		result.Status = types.CheckStatusError
 		result.Error = fmt.Sprintf("Failed to get version: %v", err)
@@ -276,6 +279,21 @@ func CheckBinaryVersion(t *task.Task, tool string, pkg types.Package, binDir str
 	compareVersion := expectedVersion
 	if compareVersion == "" {
 		compareVersion = requestedVersion
+	}
+
+	if pkg.VerifyExpr != "" {
+		ok, verifyErr := EvaluateVerifyExpr(pkg.VerifyExpr, installedVersion, compareVersion, rawOutput, "", "")
+		if verifyErr != nil {
+			result.Status = types.CheckStatusError
+			result.Error = verifyErr.Error()
+			return result
+		}
+		if ok {
+			result.Status = types.CheckStatusOK
+		} else {
+			result.Status = types.CheckStatusOutdated
+		}
+		return result
 	}
 
 	status, err := CompareVersions(installedVersion, compareVersion)
@@ -350,7 +368,7 @@ func CheckExistingInstallation(t *task.Task, name string, pkg types.Package, req
 	}
 
 	// Try to get the installed version
-	installedVersion, err := GetInstalledVersionWithMode(t, pathInfo.BinaryPath, pathInfo.VersionCommand, pkg.VersionRegex, pathInfo.Mode)
+	installedVersion, _, err := GetInstalledVersionWithMode(t, pathInfo.BinaryPath, pathInfo.VersionCommand, pkg.VersionRegex, pathInfo.Mode)
 	if err != nil {
 		t.V(2).Infof(err.Error())
 		return ""

--- a/pkg/version/clickhouse_test.go
+++ b/pkg/version/clickhouse_test.go
@@ -1,0 +1,121 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flanksource/deps/pkg/types"
+)
+
+func TestClickHouseVersionExpr(t *testing.T) {
+	expr := `(tag.contains("-stable") || tag.contains("-lts")) ? (tag.substring(1).split("-")[0].split(".").size() >= 4 ? tag.substring(1).split("-")[0].split(".")[0] + "." + tag.substring(1).split("-")[0].split(".")[1] + "." + tag.substring(1).split("-")[0].split(".")[2] + "+" + tag.substring(1).split("-")[0].split(".")[3] : tag.substring(1).split("-")[0]) : ""`
+
+	tests := []struct {
+		tag         string
+		wantVersion string
+		wantInclude bool
+	}{
+		{"v26.2.4.23-stable", "26.2.4+23", true},
+		{"v25.8.18.1-lts", "25.8.18+1", true},
+		{"v26.2.3.2-stable", "26.2.3+2", true},
+		{"v26.2.1.1139-stable", "26.2.1+1139", true},
+		{"v19.3.7-stable", "19.3.7", true},
+		{"v26.2.4.23-testing", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			versions := []types.Version{{
+				Tag:     tt.tag,
+				Version: Normalize(tt.tag),
+			}}
+
+			result, err := ApplyVersionExpr(versions, expr)
+			if err != nil {
+				t.Fatalf("ApplyVersionExpr error: %v", err)
+			}
+
+			if tt.wantInclude {
+				if len(result) == 0 {
+					t.Fatalf("expected version to be included, but was filtered out")
+				}
+				if result[0].Version != tt.wantVersion {
+					t.Errorf("Version = %q, want %q", result[0].Version, tt.wantVersion)
+				}
+				// Verify it's valid semver
+				_, err := semver.NewVersion(result[0].Version)
+				if err != nil {
+					t.Errorf("version %q is not valid semver: %v", result[0].Version, err)
+				}
+			} else {
+				if len(result) != 0 {
+					t.Errorf("expected version to be excluded, but got %v", result)
+				}
+			}
+		})
+	}
+}
+
+func TestClickHousePartialVersionConstraint(t *testing.T) {
+	expr := `(tag.contains("-stable") || tag.contains("-lts")) ? (tag.substring(1).split("-")[0].split(".").size() >= 4 ? tag.substring(1).split("-")[0].split(".")[0] + "." + tag.substring(1).split("-")[0].split(".")[1] + "." + tag.substring(1).split("-")[0].split(".")[2] + "+" + tag.substring(1).split("-")[0].split(".")[3] : tag.substring(1).split("-")[0]) : ""`
+
+	tags := []string{
+		"v26.2.4.23-stable",
+		"v26.2.3.2-stable",
+		"v25.8.18.1-lts",
+		"v26.1.4.35-stable",
+		"v25.12.8.9-stable",
+		"v25.3.14.14-lts",
+	}
+
+	versions := make([]types.Version, len(tags))
+	for i, tag := range tags {
+		versions[i] = types.Version{Tag: tag, Version: Normalize(tag)}
+	}
+
+	filtered, err := ApplyVersionExpr(versions, expr)
+	if err != nil {
+		t.Fatalf("ApplyVersionExpr error: %v", err)
+	}
+
+	// All should be valid semver now
+	for _, v := range filtered {
+		if _, err := semver.NewVersion(v.Version); err != nil {
+			t.Errorf("version %q (from tag %s) is not valid semver: %v", v.Version, v.Tag, err)
+		}
+	}
+
+	// Partial constraint "25" should match only v25.x tags
+	constraint, err := ParseConstraint("25")
+	if err != nil {
+		t.Fatalf("ParseConstraint error: %v", err)
+	}
+
+	var matched []string
+	for _, v := range filtered {
+		if constraint.Check(v.Version) {
+			matched = append(matched, v.Version)
+		}
+	}
+
+	if len(matched) != 3 {
+		t.Fatalf("expected 3 versions matching '25', got %d: %v", len(matched), matched)
+	}
+
+	// Partial constraint "26" should match only v26.x tags
+	constraint26, err := ParseConstraint("26")
+	if err != nil {
+		t.Fatalf("ParseConstraint error: %v", err)
+	}
+
+	var matched26 []string
+	for _, v := range filtered {
+		if constraint26.Check(v.Version) {
+			matched26 = append(matched26, v.Version)
+		}
+	}
+
+	if len(matched26) != 3 {
+		t.Fatalf("expected 3 versions matching '26', got %d: %v", len(matched26), matched26)
+	}
+}

--- a/pkg/version/fallback.go
+++ b/pkg/version/fallback.go
@@ -1,0 +1,38 @@
+package version
+
+import (
+	"strings"
+
+	"github.com/flanksource/gomplate/v3"
+)
+
+// EvaluateVersionFallback evaluates a version_fallback CEL expression to transform the version
+// before URL templating. Returns the original version and tag if expr is empty.
+func EvaluateVersionFallback(expr, version, tag, os, arch string) (string, string, error) {
+	if strings.TrimSpace(expr) == "" {
+		return version, tag, nil
+	}
+
+	data := map[string]interface{}{
+		"version": version,
+		"tag":     tag,
+		"os":      os,
+		"arch":    arch,
+	}
+
+	result, err := gomplate.RunTemplate(data, gomplate.Template{Expression: strings.TrimSpace(expr)})
+	if err != nil {
+		return "", "", err
+	}
+
+	if result == "" || result == version {
+		return version, tag, nil
+	}
+
+	newTag := result
+	if strings.HasPrefix(tag, "v") && !strings.HasPrefix(result, "v") {
+		newTag = "v" + result
+	}
+
+	return result, newTag, nil
+}

--- a/pkg/version/fallback_test.go
+++ b/pkg/version/fallback_test.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EvaluateVersionFallback", func() {
+	kubeExpr := `os == "linux" ? version : version.split(".")[0] + "." + version.split(".")[1] + ".0"`
+
+	It("should return minor-only version on darwin", func() {
+		ver, tag, err := EvaluateVersionFallback(kubeExpr, "1.35.3", "v1.35.3", "darwin", "arm64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ver).To(Equal("1.35.0"))
+		Expect(tag).To(Equal("v1.35.0"))
+	})
+
+	It("should return original version on linux", func() {
+		ver, tag, err := EvaluateVersionFallback(kubeExpr, "1.35.3", "v1.35.3", "linux", "amd64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ver).To(Equal("1.35.3"))
+		Expect(tag).To(Equal("v1.35.3"))
+	})
+
+	It("should return minor-only version on windows", func() {
+		ver, tag, err := EvaluateVersionFallback(kubeExpr, "1.35.3", "v1.35.3", "windows", "amd64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ver).To(Equal("1.35.0"))
+		Expect(tag).To(Equal("v1.35.0"))
+	})
+
+	It("should return original version for empty expression", func() {
+		ver, tag, err := EvaluateVersionFallback("", "1.35.3", "v1.35.3", "darwin", "arm64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ver).To(Equal("1.35.3"))
+		Expect(tag).To(Equal("v1.35.3"))
+	})
+
+	It("should return error for invalid expression", func() {
+		_, _, err := EvaluateVersionFallback("invalid_func()", "1.35.3", "v1.35.3", "darwin", "arm64")
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/version/helpers.go
+++ b/pkg/version/helpers.go
@@ -88,7 +88,6 @@ func getShellBinary() string {
 }
 
 func CompareVersions(installed, expected string) (types.CheckStatus, error) {
-	// Normalize versions for comparison
 	normalizedInstalled := Normalize(installed)
 	normalizedExpected := Normalize(expected)
 
@@ -96,10 +95,13 @@ func CompareVersions(installed, expected string) (types.CheckStatus, error) {
 		return types.CheckStatusOK, nil
 	}
 
-	// Try semantic version comparison
+	// Prefix match: "26.2.5.45" matches "26.2.5.45-stable", "7.4.6" matches "7.4.6.1"
+	if strings.HasPrefix(normalizedExpected, normalizedInstalled) || strings.HasPrefix(normalizedInstalled, normalizedExpected) {
+		return types.CheckStatusOK, nil
+	}
+
 	cmp, err := Compare(installed, expected)
 	if err != nil {
-		// If semantic comparison fails, use string comparison
 		if normalizedInstalled != normalizedExpected {
 			return types.CheckStatusOutdated, nil
 		}

--- a/pkg/version/helpers.go
+++ b/pkg/version/helpers.go
@@ -87,9 +87,7 @@ func getShellBinary() string {
 	return "sh"
 }
 
-// compareVersions compares installed version against expected version
-// Returns the appropriate CheckStatus and any error
-func compareVersions(installed, expected string) (types.CheckStatus, error) {
+func CompareVersions(installed, expected string) (types.CheckStatus, error) {
 	// Normalize versions for comparison
 	normalizedInstalled := Normalize(installed)
 	normalizedExpected := Normalize(expected)

--- a/pkg/version/resolver.go
+++ b/pkg/version/resolver.go
@@ -332,8 +332,8 @@ func (r *VersionResolver) enhanceVersionError(packageName, requestedVersion stri
 
 	// Build enhanced error message
 	var errorMsg strings.Builder
-	errorMsg.WriteString(fmt.Sprintf("Version %s not found for %s\n\n", requestedVersion, packageName))
-	errorMsg.WriteString(fmt.Sprintf("Available versions (%d total):\n", len(availableVersions)))
+	fmt.Fprintf(&errorMsg, "Version %s not found for %s\n\n", requestedVersion, packageName)
+	fmt.Fprintf(&errorMsg, "Available versions (%d total):\n", len(availableVersions))
 
 	// Show latest versions (up to 10)
 	maxVersions := 10
@@ -347,16 +347,16 @@ func (r *VersionResolver) enhanceVersionError(packageName, requestedVersion stri
 		if v.Prerelease {
 			suffix += " (prerelease)"
 		}
-		errorMsg.WriteString(fmt.Sprintf("  %s%s\n", v.Tag, suffix))
+		fmt.Fprintf(&errorMsg, "  %s%s\n", v.Tag, suffix)
 	}
 
 	if len(availableVersions) > maxVersions {
-		errorMsg.WriteString(fmt.Sprintf("  ... and %d more versions\n", len(availableVersions)-maxVersions))
+		fmt.Fprintf(&errorMsg, "  ... and %d more versions\n", len(availableVersions)-maxVersions)
 	}
 
 	// Suggest closest match
 	if suggestion := r.suggestClosestVersion(requestedVersion, availableVersions); suggestion != "" {
-		errorMsg.WriteString(fmt.Sprintf("\nDid you mean: %s?", suggestion))
+		fmt.Fprintf(&errorMsg, "\nDid you mean: %s?", suggestion)
 	}
 
 	return fmt.Errorf("%s", errorMsg.String())

--- a/pkg/version/verify.go
+++ b/pkg/version/verify.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flanksource/gomplate/v3"
+)
+
+// EvaluateVerifyExpr evaluates a verify_expr CEL expression to determine if the installed
+// version is acceptable. Returns true if verification passes.
+func EvaluateVerifyExpr(expr, installed, expected, output, os, arch string) (bool, error) {
+	if strings.TrimSpace(expr) == "" {
+		return false, fmt.Errorf("empty verify_expr")
+	}
+
+	data := map[string]interface{}{
+		"installed": installed,
+		"expected":  expected,
+		"output":    output,
+		"os":        os,
+		"arch":      arch,
+	}
+
+	result, err := gomplate.RunTemplate(data, gomplate.Template{Expression: strings.TrimSpace(expr)})
+	if err != nil {
+		return false, fmt.Errorf("verify_expr evaluation failed: %w", err)
+	}
+
+	return result == "true", nil
+}

--- a/pkg/version/verify_test.go
+++ b/pkg/version/verify_test.go
@@ -1,0 +1,44 @@
+package version
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EvaluateVerifyExpr", func() {
+	jdk8Expr := `installed == expected || installed.startsWith("1.8.0") || installed.startsWith("8.0.")`
+
+	It("should accept 1.8.0 for jdk8", func() {
+		ok, err := EvaluateVerifyExpr(jdk8Expr, "1.8.0", "jdk8u482-b08", "1.8.0", "linux", "amd64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	})
+
+	It("should accept 8.0.482+8 for jdk8", func() {
+		ok, err := EvaluateVerifyExpr(jdk8Expr, "8.0.482+8", "8.0.482+8", "8.0.482+8", "linux", "amd64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	})
+
+	It("should accept exact match", func() {
+		ok, err := EvaluateVerifyExpr(`installed == expected`, "1.35.0", "1.35.0", "1.35.0", "linux", "amd64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	})
+
+	It("should reject mismatch", func() {
+		ok, err := EvaluateVerifyExpr(`installed == expected`, "1.34.0", "1.35.0", "1.34.0", "linux", "amd64")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should return error for invalid expression", func() {
+		_, err := EvaluateVerifyExpr("bad_func()", "1.0.0", "1.0.0", "1.0.0", "linux", "amd64")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return error for empty expression", func() {
+		_, err := EvaluateVerifyExpr("", "1.0.0", "1.0.0", "1.0.0", "linux", "amd64")
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/version/version_ginkgo_test.go
+++ b/pkg/version/version_ginkgo_test.go
@@ -118,6 +118,22 @@ OpenJDK 64-Bit Server VM Temurin-21.0.5+11 (build 21.0.5+11, mixed mode, sharing
 		)
 	})
 
+	Describe("CompareVersions", func() {
+		DescribeTable("should compare versions with prefix matching",
+			func(installed, expected string, want types.CheckStatus) {
+				status, err := CompareVersions(installed, expected)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(status).To(Equal(want))
+			},
+			Entry("exact match", "1.2.3", "1.2.3", types.CheckStatusOK),
+			Entry("v prefix on expected", "1.2.3", "v1.2.3", types.CheckStatusOK),
+			Entry("installed prefixes expected (clickhouse style)", "26.2.5.45", "26.2.5.45-stable", types.CheckStatusOK),
+			Entry("expected prefixes installed", "7.4.6.1", "7.4.6", types.CheckStatusOK),
+			Entry("different versions", "1.2.3", "1.2.4", types.CheckStatusOutdated),
+			Entry("newer installed", "1.3.0", "1.2.9", types.CheckStatusNewer),
+		)
+	})
+
 	Describe("IsCompatible", func() {
 		DescribeTable("should check version compatibility",
 			func(installed, required string, expected bool) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post-install version verification now fails with a distinct exit code on mismatches
  * Added a registry entry for Smallstep CLI

* **Bug Fixes**
  * Reject incompatible-architecture assets instead of falling back silently
  * Better diagnostics for missing or mismatched system libraries (macOS/Linux)
  * Installer forces reinstall when on-disk binary arch doesn't match requested arch

* **Improvements**
  * More precise version parsing for jq and ClickHouse
  * Version-command errors now include stderr in messages

* **Tests**
  * Added/updated tests covering dylib diagnostics, asset filtering and ClickHouse version parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->