### PR TITLE
feat(registry): add mission-control plugin packages

### DIFF
--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -62,6 +62,28 @@ registry:
             - delete("META-INF")
             - unarchive(glob("*.txz")[0])
             # - move(glob("*:dir")[0], "postgres")
+    postgres-mc-plugin:
+        name: postgres-mc-plugin
+        manager: go
+        repo: flanksource/mission-control-plugins
+        version_expr: 'tag.startsWith("postgres/") ? tag.substring(9) : ""'
+        binary_name: postgres
+        extra:
+            import_path: github.com/flanksource/mission-control-plugins/postgres
+        wrapper_script: |
+            #!/bin/sh
+            exec "{{.binDir}}/postgres" "$@"
+    kubernetes-logs-mc-plugin:
+        name: kubernetes-logs-mc-plugin
+        manager: go
+        repo: flanksource/mission-control-plugins
+        version_expr: 'tag.startsWith("kubernetes-logs/") ? tag.substring(16) : ""'
+        binary_name: kubernetes-logs
+        extra:
+            import_path: github.com/flanksource/mission-control-plugins/kubernetes-logs
+        wrapper_script: |
+            #!/bin/sh
+            exec "{{.binDir}}/kubernetes-logs" "$@"
     gomplate:
         repo: hairyhenderson/gomplate
         asset_patterns:


### PR DESCRIPTION
Add built-in deps registry entries for Mission Control plugins.

The Postgres and Kubernetes logs plugins are released from `flanksource/mission-control-plugins` with plugin-scoped tags like `postgres/v1.0.0`.
These entries map those tags to standard Go module versions, install the plugin modules via `go install`, and create wrapper scripts matching the deps package names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new built-in plugins: `postgres-mc-plugin` and `kubernetes-logs-mc-plugin` are now available for use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/deps/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->