### PR TITLE
fix(registry): update mission-control plugin release assets

### DIFF
--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -63,27 +63,33 @@ registry:
             - unarchive(glob("*.txz")[0])
             # - move(glob("*:dir")[0], "postgres")
     postgres-mc-plugin:
-        name: postgres-mc-plugin
-        manager: go
+        name: postgres
+        manager: github_release
         repo: flanksource/mission-control-plugins
-        version_expr: 'tag.startsWith("postgres/") ? tag.substring(9) : ""'
-        binary_name: postgres
-        extra:
-            import_path: github.com/flanksource/mission-control-plugins/postgres
+        binary_path: postgres_mc_plugin
+        asset_patterns:
+            darwin-amd64: postgres_{{.tag}}_darwin_amd64.tar.gz
+            darwin-arm64: postgres_{{.tag}}_darwin_arm64.tar.gz
+            linux-amd64: postgres_{{.tag}}_linux_amd64.tar.gz
+            linux-arm64: postgres_{{.tag}}_linux_arm64.tar.gz
+        checksum_file: "{{.tag}}_checksums.txt"
         wrapper_script: |
             #!/bin/sh
-            exec "{{.binDir}}/postgres" "$@"
+            exec "{{.binDir}}/postgres-mc-plugin" "$@"
     kubernetes-logs-mc-plugin:
-        name: kubernetes-logs-mc-plugin
-        manager: go
+        name: kubernetes-logs
+        manager: github_release
         repo: flanksource/mission-control-plugins
-        version_expr: 'tag.startsWith("kubernetes-logs/") ? tag.substring(16) : ""'
-        binary_name: kubernetes-logs
-        extra:
-            import_path: github.com/flanksource/mission-control-plugins/kubernetes-logs
+        binary_path: kubernetes-logs_mc_plugin
+        asset_patterns:
+            darwin-amd64: kubernetes-logs_{{.tag}}_darwin_amd64.tar.gz
+            darwin-arm64: kubernetes-logs_{{.tag}}_darwin_arm64.tar.gz
+            linux-amd64: kubernetes-logs_{{.tag}}_linux_amd64.tar.gz
+            linux-arm64: kubernetes-logs_{{.tag}}_linux_arm64.tar.gz
+        checksum_file: "{{.tag}}_checksums.txt"
         wrapper_script: |
             #!/bin/sh
-            exec "{{.binDir}}/kubernetes-logs" "$@"
+            exec "{{.binDir}}/kubernetes-logs-mc-plugin" "$@"
     gomplate:
         repo: hairyhenderson/gomplate
         asset_patterns:


### PR DESCRIPTION
Mission Control plugins now ship under conventional shared release tags like `v1.0.1`, with per-plugin assets in the same release.

Update the deps registry entries for `postgres-mc-plugin` and `kubernetes-logs-mc-plugin` to use GitHub release assets, shared checksum files, and the new extracted plugin binary names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated how the postgres and kubernetes-logs mission-control plugins are distributed and managed, improving plugin deployment and installation processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/deps/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->