### PR TITLE
fix: add remaining mission-control plugins to registry

### DIFF
--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -90,6 +90,62 @@ registry:
         wrapper_script: |
             #!/bin/sh
             exec "{{.binDir}}/kubernetes-logs-mc-plugin" "$@"
+    arthas-mc-plugin:
+        name: arthas
+        manager: github_release
+        repo: flanksource/mission-control-plugins
+        binary_path: arthas_mc_plugin
+        asset_patterns:
+            darwin-amd64: arthas_{{.tag}}_darwin_amd64.tar.gz
+            darwin-arm64: arthas_{{.tag}}_darwin_arm64.tar.gz
+            linux-amd64: arthas_{{.tag}}_linux_amd64.tar.gz
+            linux-arm64: arthas_{{.tag}}_linux_arm64.tar.gz
+        checksum_file: "{{.tag}}_checksums.txt"
+        wrapper_script: |
+            #!/bin/sh
+            exec "{{.binDir}}/arthas-mc-plugin" "$@"
+    golang-mc-plugin:
+        name: golang
+        manager: github_release
+        repo: flanksource/mission-control-plugins
+        binary_path: golang_mc_plugin
+        asset_patterns:
+            darwin-amd64: golang_{{.tag}}_darwin_amd64.tar.gz
+            darwin-arm64: golang_{{.tag}}_darwin_arm64.tar.gz
+            linux-amd64: golang_{{.tag}}_linux_amd64.tar.gz
+            linux-arm64: golang_{{.tag}}_linux_arm64.tar.gz
+        checksum_file: "{{.tag}}_checksums.txt"
+        wrapper_script: |
+            #!/bin/sh
+            exec "{{.binDir}}/golang-mc-plugin" "$@"
+    inspektor-gadget-mc-plugin:
+        name: inspektor-gadget
+        manager: github_release
+        repo: flanksource/mission-control-plugins
+        binary_path: inspektor-gadget_mc_plugin
+        asset_patterns:
+            darwin-amd64: inspektor-gadget_{{.tag}}_darwin_amd64.tar.gz
+            darwin-arm64: inspektor-gadget_{{.tag}}_darwin_arm64.tar.gz
+            linux-amd64: inspektor-gadget_{{.tag}}_linux_amd64.tar.gz
+            linux-arm64: inspektor-gadget_{{.tag}}_linux_arm64.tar.gz
+        checksum_file: "{{.tag}}_checksums.txt"
+        wrapper_script: |
+            #!/bin/sh
+            exec "{{.binDir}}/inspektor-gadget-mc-plugin" "$@"
+    sql-server-mc-plugin:
+        name: sql-server
+        manager: github_release
+        repo: flanksource/mission-control-plugins
+        binary_path: sql-server_mc_plugin
+        asset_patterns:
+            darwin-amd64: sql-server_{{.tag}}_darwin_amd64.tar.gz
+            darwin-arm64: sql-server_{{.tag}}_darwin_arm64.tar.gz
+            linux-amd64: sql-server_{{.tag}}_linux_amd64.tar.gz
+            linux-arm64: sql-server_{{.tag}}_linux_arm64.tar.gz
+        checksum_file: "{{.tag}}_checksums.txt"
+        wrapper_script: |
+            #!/bin/sh
+            exec "{{.binDir}}/sql-server-mc-plugin" "$@"
     gomplate:
         repo: hairyhenderson/gomplate
         asset_patterns:


### PR DESCRIPTION
The registry only included installers for postgres and kubernetes-logs mission-control plugins.

Add the remaining plugins published by flanksource/mission-control-plugins so they can be installed through deps as well: arthas, golang, inspektor-gadget, and sql-server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added built-in registry entries for four mission-control plugins: `arthas-mc-plugin`, `golang-mc-plugin`, `inspektor-gadget-mc-plugin`, and `sql-server-mc-plugin`. These are now available for use without additional configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/deps/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->