### PR TITLE
fix: publish release after matrix uploads complete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
           file_glob: true
           file: deps-*.{exe,tar.gz,zip,sha256}
           tag: ${{ needs.version.outputs.tag }}
+          draft: true
 
   release:
     name: Create Release
@@ -145,4 +146,4 @@ jobs:
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes -f tag_name="$TAG" --jq '.body')
-          gh release edit "$TAG" --title "Release $TAG" --notes "$NOTES"
+          gh release edit "$TAG" --title "Release $TAG" --notes "$NOTES" --draft=false


### PR DESCRIPTION
Release builds upload assets from multiple matrix jobs.

The first completed matrix job was creating a published GitHub Release, causing later jobs to fail when uploading assets to an immutable release.

Keep the release as a draft during matrix uploads, then publish it in the final release job after all builds complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to create releases as drafts before publishing, improving the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/deps/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->