### PR TITLE
feat: Do not use GitHub API when possible

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -323,6 +323,37 @@ func fetchChecksumFromMultipleURLs(checksumURLs []string, checksumNames []string
 	}
 }
 
+// resolveConfiguredChecksum fetches the expected checksum from the configured checksum
+// URL(s) when no literal checksum was provided. fileURL identifies which entry to match
+// in a multi-file checksum list (matched by basename). Returns ok=false when no checksum
+// URL is configured or the fetch/parse fails (e.g. offline), so callers can fall back to
+// the existing no-checksum behavior rather than hard-failing.
+func resolveConfiguredChecksum(config *downloadConfig, fileURL string, t *task.Task) (formatted, checksumType string, ok bool) {
+	switch {
+	case config.checksumURL != "":
+		value, ctype, sources, err := fetchChecksumFromURL(config.checksumURL, fileURL, t, config.timeout)
+		if err != nil {
+			return "", "", false
+		}
+		if config.checksumSource == "" {
+			config.checksumSource = strings.Join(sources, ",")
+		}
+		return checksum.FormatChecksum(value, checksum.HashType(ctype)), ctype, true
+	case len(config.checksumURLs) > 0:
+		value, ctype, _, sources, err := fetchChecksumFromMultipleURLs(
+			config.checksumURLs, config.checksumNames, config.checksumExpr, fileURL, config.os, config.arch, t, config.timeout)
+		if err != nil {
+			return "", "", false
+		}
+		if config.checksumSource == "" {
+			config.checksumSource = strings.Join(sources, ",")
+		}
+		return checksum.FormatChecksum(value, checksum.HashType(ctype)), ctype, true
+	default:
+		return "", "", false
+	}
+}
+
 // Download downloads a file with optional configuration
 func Download(url, dest string, t *task.Task, opts ...DownloadOption) error {
 	// Parse options
@@ -341,6 +372,18 @@ func Download(url, dest string, t *task.Task, opts ...DownloadOption) error {
 	if cachePath, isCached := cache.IsCached(config.cacheDir, url, filename); isCached {
 		if t != nil {
 			t.V(3).Infof("Found in cache: %s", cachePath)
+		}
+
+		// If no literal checksum was provided but a checksum URL/file is configured,
+		// fetch it now so cached files are validated too — not just fresh downloads.
+		// (matches by basename of the original asset URL).
+		if config.expectedChecksum == "" {
+			if formatted, ctype, ok := resolveConfiguredChecksum(config, url, t); ok {
+				config.expectedChecksum = formatted
+				if config.checksumType == "" {
+					config.checksumType = ctype
+				}
+			}
 		}
 
 		// If we have a checksum, validate cached file

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -323,35 +323,36 @@ func fetchChecksumFromMultipleURLs(checksumURLs []string, checksumNames []string
 	}
 }
 
-// resolveConfiguredChecksum fetches the expected checksum from the configured checksum
-// URL(s) when no literal checksum was provided. fileURL identifies which entry to match
-// in a multi-file checksum list (matched by basename). Returns ok=false when no checksum
-// URL is configured or the fetch/parse fails (e.g. offline), so callers can fall back to
-// the existing no-checksum behavior rather than hard-failing.
-func resolveConfiguredChecksum(config *downloadConfig, fileURL string, t *task.Task) (formatted, checksumType string, ok bool) {
+// getChecksum returns the expected checksum and hash type: the inline value if set,
+// otherwise fetched from the configured checksum URL/file. Empty if none or the fetch fails.
+func getChecksum(config *downloadConfig, fileURL string, t *task.Task) (value, hashType string) {
+	// Inline checksum already provided — nothing to fetch.
+	if config.expectedChecksum != "" {
+		return config.expectedChecksum, config.checksumType
+	}
+
 	switch {
 	case config.checksumURL != "":
-		value, ctype, sources, err := fetchChecksumFromURL(config.checksumURL, fileURL, t, config.timeout)
+		v, ct, sources, err := fetchChecksumFromURL(config.checksumURL, fileURL, t, config.timeout)
 		if err != nil {
-			return "", "", false
+			return "", ""
 		}
 		if config.checksumSource == "" {
 			config.checksumSource = strings.Join(sources, ",")
 		}
-		return checksum.FormatChecksum(value, checksum.HashType(ctype)), ctype, true
+		return checksum.FormatChecksum(v, checksum.HashType(ct)), ct
 	case len(config.checksumURLs) > 0:
-		value, ctype, _, sources, err := fetchChecksumFromMultipleURLs(
+		v, ct, _, sources, err := fetchChecksumFromMultipleURLs(
 			config.checksumURLs, config.checksumNames, config.checksumExpr, fileURL, config.os, config.arch, t, config.timeout)
 		if err != nil {
-			return "", "", false
+			return "", ""
 		}
 		if config.checksumSource == "" {
 			config.checksumSource = strings.Join(sources, ",")
 		}
-		return checksum.FormatChecksum(value, checksum.HashType(ctype)), ctype, true
-	default:
-		return "", "", false
+		return checksum.FormatChecksum(v, checksum.HashType(ct)), ct
 	}
+	return "", ""
 }
 
 // Download downloads a file with optional configuration
@@ -374,15 +375,11 @@ func Download(url, dest string, t *task.Task, opts ...DownloadOption) error {
 			t.V(3).Infof("Found in cache: %s", cachePath)
 		}
 
-		// If no literal checksum was provided but a checksum URL/file is configured,
-		// fetch it now so cached files are validated too — not just fresh downloads.
-		// (matches by basename of the original asset URL).
-		if config.expectedChecksum == "" {
-			if formatted, ctype, ok := resolveConfiguredChecksum(config, url, t); ok {
-				config.expectedChecksum = formatted
-				if config.checksumType == "" {
-					config.checksumType = ctype
-				}
+		// Validate cached files just like fresh downloads.
+		if value, hashType := getChecksum(config, url, t); value != "" {
+			config.expectedChecksum = value
+			if hashType != "" {
+				config.checksumType = hashType
 			}
 		}
 

--- a/pkg/manager/github/git_refs.go
+++ b/pkg/manager/github/git_refs.go
@@ -47,6 +47,55 @@ func gitRefsURL(owner, repo string) string {
 	return u.String()
 }
 
+// ResolveLatestTagViaRedirect resolves the "latest" release tag without using the
+// rate-limited GitHub REST API.
+//
+// GitHub serves https://github.com/{owner}/{repo}/releases/latest
+// as a 302 redirect to .../releases/tag/{tag}; this reads that redirect's Location header.
+func ResolveLatestTagViaRedirect(ctx context.Context, owner, repo string) (string, error) {
+	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/latest", owner, repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, releaseURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "flanksource/deps")
+
+	client := gitRefsHTTPClient()
+	// Capture the redirect instead of following it (following it would hit the
+	// rendered release page, but the tag is already in the Location header).
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve latest release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
+		return "", fmt.Errorf("unexpected status %d resolving latest release for %s/%s", resp.StatusCode, owner, repo)
+	}
+
+	const marker = "/releases/tag/"
+	location := resp.Header.Get("Location")
+	idx := strings.LastIndex(location, marker)
+	if idx == -1 {
+		return "", fmt.Errorf("unexpected redirect target %q resolving latest release for %s/%s", location, owner, repo)
+	}
+
+	tag := strings.Trim(location[idx+len(marker):], "/")
+	if decoded, decErr := url.PathUnescape(tag); decErr == nil {
+		tag = decoded
+	}
+	if tag == "" {
+		return "", fmt.Errorf("empty tag in redirect target %q for %s/%s", location, owner, repo)
+	}
+
+	return tag, nil
+}
+
 // DiscoverVersionsViaGit fetches tags from a GitHub repository using the git HTTP protocol.
 // This avoids GitHub API rate limits by using the git-upload-pack protocol.
 // URL format: https://github.com/{owner}/{repo}.git/info/refs?service=git-upload-pack

--- a/pkg/manager/github/git_refs.go
+++ b/pkg/manager/github/git_refs.go
@@ -47,11 +47,8 @@ func gitRefsURL(owner, repo string) string {
 	return u.String()
 }
 
-// ResolveLatestTagViaRedirect resolves the "latest" release tag without using the
-// rate-limited GitHub REST API.
-//
-// GitHub serves https://github.com/{owner}/{repo}/releases/latest
-// as a 302 redirect to .../releases/tag/{tag}; this reads that redirect's Location header.
+// ResolveLatestTagViaRedirect resolves the "latest" tag with no REST API call by reading
+// the Location header of the github.com/{owner}/{repo}/releases/latest 302 redirect.
 func ResolveLatestTagViaRedirect(ctx context.Context, owner, repo string) (string, error) {
 	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/latest", owner, repo)
 

--- a/pkg/manager/github/git_refs_transport_test.go
+++ b/pkg/manager/github/git_refs_transport_test.go
@@ -2,11 +2,14 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/flanksource/deps/pkg/manager"
+	"github.com/flanksource/deps/pkg/platform"
 	"github.com/flanksource/deps/pkg/types"
 )
 
@@ -14,6 +17,77 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+// redirectClient returns a client func whose transport answers every request with a
+// 302 redirect to the given Location (mimicking github.com/.../releases/latest).
+func redirectClient(location string) func() *http.Client {
+	return func() *http.Client {
+		return &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				header := make(http.Header)
+				header.Set("Location", location)
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Header:     header,
+				}, nil
+			}),
+		}
+	}
+}
+
+func TestResolveLatestTagViaRedirect(t *testing.T) {
+	previousClient := gitRefsHTTPClient
+	defer func() { gitRefsHTTPClient = previousClient }()
+	gitRefsHTTPClient = redirectClient("https://github.com/flanksource/mission-control-plugins/releases/tag/v1.7.1")
+
+	tag, err := ResolveLatestTagViaRedirect(context.Background(), "flanksource", "mission-control-plugins")
+	if err != nil {
+		t.Fatalf("ResolveLatestTagViaRedirect failed: %v", err)
+	}
+	if tag != "v1.7.1" {
+		t.Fatalf("expected tag v1.7.1, got %q", tag)
+	}
+}
+
+// TestHandleRateLimitFallbackLatestResolvesTag guards against the "vlatest" regression:
+// strict mode + checksum_file + version "latest" with no explicit fallback_version must
+// resolve the real tag via the redirect rather than building "v"+"latest" as the tag.
+// version_expr is set so the package does not qualify for the no-API fast path and
+// genuinely reaches handleRateLimitFallback.
+func TestHandleRateLimitFallbackLatestResolvesTag(t *testing.T) {
+	previousClient := gitRefsHTTPClient
+	defer func() { gitRefsHTTPClient = previousClient }()
+	gitRefsHTTPClient = redirectClient("https://github.com/owner/test-tool/releases/tag/v2.0.0")
+
+	mgr := NewGitHubReleaseManager()
+	pkg := types.Package{
+		Name:         "test-tool",
+		Repo:         "owner/test-tool",
+		Manager:      "github_release",
+		VersionExpr:  "version",
+		ChecksumFile: "{{.tag}}_checksums.txt",
+		AssetPatterns: map[string]string{
+			"linux-amd64": "{{.name}}-{{.os}}-{{.arch}}.tar.gz",
+		},
+	}
+	plat := platform.Platform{OS: "linux", Arch: "amd64"}
+
+	ctx := manager.WithStrictChecksum(context.Background(), true)
+	resolution, err := mgr.handleRateLimitFallback(ctx, pkg, "latest", plat, fmt.Errorf("API rate limit exceeded"))
+	if err != nil {
+		t.Fatalf("handleRateLimitFallback failed: %v", err)
+	}
+	if strings.Contains(resolution.DownloadURL, "vlatest") {
+		t.Fatalf("download URL must not contain a bogus vlatest tag: %s", resolution.DownloadURL)
+	}
+	if !strings.Contains(resolution.DownloadURL, "v2.0.0") {
+		t.Fatalf("expected resolved tag v2.0.0 in download URL, got %s", resolution.DownloadURL)
+	}
+	if resolution.ChecksumURL != "https://github.com/owner/test-tool/releases/download/v2.0.0/v2.0.0_checksums.txt" {
+		t.Fatalf("unexpected checksum URL: %s", resolution.ChecksumURL)
+	}
 }
 
 func TestDiscoverVersionsViaGitUsesSingleServiceQueryParam(t *testing.T) {

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -1011,7 +1011,20 @@ func (m *GitHubReleaseManager) handleRateLimitFallback(ctx context.Context, pkg 
 		versionForTemplate = fallbackVersion
 	}
 
-	// Build resolution without checksum
+	// "latest" with no concrete fallback_version has no version to template — deriving a
+	// tag as "v"+"latest" would produce a bogus "vlatest" download URL. Resolve the real
+	// tag via the releases/latest redirect instead (still no REST API call).
+	if versionForTemplate == "latest" || versionForTemplate == "" {
+		parts := strings.Split(pkg.Repo, "/")
+		if len(parts) == 2 {
+			if tag, tagErr := ResolveLatestTagViaRedirect(ctx, parts[0], parts[1]); tagErr == nil {
+				return m.buildDeterministicResolution(pkg, versionpkg.Normalize(tag), tag, plat)
+			}
+		}
+		return nil, fmt.Errorf("rate limited and could not resolve a concrete version for fallback: %w", originalErr)
+	}
+
+	// Build resolution from the concrete fallback version
 	return m.buildFallbackResolution(pkg, versionForTemplate, plat)
 }
 

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -170,10 +170,8 @@ func (m *GitHubReleaseManager) Resolve(ctx context.Context, pkg types.Package, v
 	}
 	owner, repo := parts[0], parts[1]
 
-	// No-API fast path: packages with a deterministic asset pattern and a checksum_file can
-	// be resolved entirely without the rate-limited REST API — the download URL is computed
-	// from the pattern and the checksum comes from the checksum_file. Covers both "latest"
-	// (tag via the releases/latest redirect) and pinned versions (tag derived from version).
+	// No-API fast path: deterministic asset pattern + checksum_file => no REST API call,
+	// for both latest (tag via redirect) and pinned versions.
 	if m.canResolveWithoutAPI(pkg, plat) {
 		if resolution, err := m.resolveWithoutAPI(ctx, pkg, owner, repo, version, plat); err == nil {
 			logger.V(3).Infof("Resolved %s@%s without REST API", pkg.Name, version)
@@ -183,9 +181,8 @@ func (m *GitHubReleaseManager) Resolve(ctx context.Context, pkg types.Package, v
 		}
 	}
 
-	// Fast path for "latest" (no url_template). Resolve the concrete tag via the
-	// releases/latest redirect first (no API) so the single REST call is only for the
-	// asset list + digest (the checksum), never for the tag itself.
+	// Fast path for "latest": resolve the tag via redirect (no API) so the REST call is
+	// only for the asset list + digest, never the tag.
 	var tagName string
 	if version == "latest" && pkg.URLTemplate == "" {
 		endpoint := "latest"
@@ -457,8 +454,7 @@ func (m *GitHubReleaseManager) buildResolutionFromRelease(pkg types.Package, rel
 		resolution.Checksum = matched.Digest // Already in "sha256:..." format from REST API
 	}
 
-	// Wire checksum_file as a checksum source (used when the asset has no digest, and
-	// keeps verification possible without the REST API on subsequent installs).
+	// Fall back to checksum_file when the asset has no digest.
 	if resolution.Checksum == "" && pkg.ChecksumFile != "" {
 		if checksumURL := m.buildChecksumURL(pkg, matched.Name, version, tagName, plat); checksumURL != "" {
 			resolution.ChecksumURL = checksumURL
@@ -985,10 +981,8 @@ func isRateLimitError(err error) bool {
 // If strict checksum mode is enabled, it returns the error. Otherwise, it builds
 // a resolution without checksum using the fallback version and url_template or asset_patterns.
 func (m *GitHubReleaseManager) handleRateLimitFallback(ctx context.Context, pkg types.Package, version string, plat platform.Platform, originalErr error) (*types.Resolution, error) {
-	// Strict checksum mode requires a verifiable checksum. The REST API (the usual
-	// source via the asset digest) is rate limited, but a configured checksum_file is
-	// fetched directly from the release assets and is not rate limited — so strict mode
-	// can still be honored when checksum_file is set.
+	// Strict mode needs a checksum; a checksum_file provides one off-API, so only bail
+	// when there's no checksum_file.
 	if manager.GetStrictChecksum(ctx) && pkg.ChecksumFile == "" {
 		return nil, fmt.Errorf("rate limited and --strict-checksum requires checksum verification: %w", originalErr)
 	}
@@ -1019,9 +1013,8 @@ func (m *GitHubReleaseManager) handleRateLimitFallback(ctx context.Context, pkg 
 		versionForTemplate = fallbackVersion
 	}
 
-	// "latest" with no concrete fallback_version has no version to template — deriving a
-	// tag as "v"+"latest" would produce a bogus "vlatest" download URL. Resolve the real
-	// tag via the releases/latest redirect instead (still no REST API call).
+	// For "latest" with no concrete fallback_version, resolve the real tag via redirect
+	// rather than building a bogus "vlatest" URL.
 	if versionForTemplate == "latest" || versionForTemplate == "" {
 		parts := strings.Split(pkg.Repo, "/")
 		if len(parts) == 2 {
@@ -1032,7 +1025,6 @@ func (m *GitHubReleaseManager) handleRateLimitFallback(ctx context.Context, pkg 
 		return nil, fmt.Errorf("rate limited and could not resolve a concrete version for fallback: %w", originalErr)
 	}
 
-	// Build resolution from the concrete fallback version
 	return m.buildFallbackResolution(pkg, versionForTemplate, plat)
 }
 
@@ -1050,10 +1042,8 @@ func (m *GitHubReleaseManager) hasNonWildcardAssetPattern(pkg types.Package, pla
 	return !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?")
 }
 
-// canResolveWithoutAPI reports whether a package can be fully resolved without the
-// rate-limited REST API: it needs a deterministic (non-wildcard) asset pattern for the
-// platform to build the download URL, and a checksum_file to verify it. Packages relying
-// on version_expr/version_fallback transforms keep using the REST path for correctness.
+// canResolveWithoutAPI reports whether a package can be resolved without the REST API:
+// a non-wildcard asset pattern (for the URL) + a checksum_file, and no version transforms.
 func (m *GitHubReleaseManager) canResolveWithoutAPI(pkg types.Package, plat platform.Platform) bool {
 	return pkg.ChecksumFile != "" &&
 		pkg.VersionExpr == "" &&
@@ -1061,11 +1051,9 @@ func (m *GitHubReleaseManager) canResolveWithoutAPI(pkg types.Package, plat plat
 		m.hasNonWildcardAssetPattern(pkg, plat)
 }
 
-// resolveWithoutAPI resolves a version entirely off the REST API for packages that have a
-// deterministic asset pattern and a checksum_file. The tag comes from the releases/latest
-// redirect for "latest", or is derived from the version for pinned versions; the checksum
-// comes from the checksum_file. Returns an error (so the caller falls back to the REST
-// path) for "stable" (needs the release list) or when no checksum source could be derived.
+// resolveWithoutAPI resolves a version with no REST API call: the tag comes from the
+// releases/latest redirect (latest) or the version itself (pinned). Errors back to the
+// REST path for "stable" or when no checksum source results.
 func (m *GitHubReleaseManager) resolveWithoutAPI(ctx context.Context, pkg types.Package, owner, repo, version string, plat platform.Platform) (*types.Resolution, error) {
 	var resolution *types.Resolution
 	var err error
@@ -1096,9 +1084,7 @@ func (m *GitHubReleaseManager) resolveWithoutAPI(ctx context.Context, pkg types.
 	return resolution, nil
 }
 
-// buildChecksumURL constructs the checksum file URL from pkg.ChecksumFile. ChecksumFile
-// may be a CEL expression, a Go template, a full URL, or (most commonly for github_release)
-// a release asset filename, in which case it is resolved to the release's download URL.
+// buildChecksumURL turns pkg.ChecksumFile (a full URL, or a release asset name) into a URL.
 func (m *GitHubReleaseManager) buildChecksumURL(pkg types.Package, assetName, version, tag string, plat platform.Platform) string {
 	if pkg.ChecksumFile == "" {
 		return ""
@@ -1126,9 +1112,7 @@ func (m *GitHubReleaseManager) buildChecksumURL(pkg types.Package, assetName, ve
 	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", pkg.Repo, tag, checksumFile)
 }
 
-// buildFallbackResolution builds a resolution using url_template or asset_patterns when the
-// REST API is unavailable, deriving the tag from the version using the conventional
-// "v"+version GitHub tag format.
+// buildFallbackResolution resolves a pinned version, deriving the tag as "v"+version.
 func (m *GitHubReleaseManager) buildFallbackResolution(pkg types.Package, version string, plat platform.Platform) (*types.Resolution, error) {
 	tagName := version
 	if !strings.HasPrefix(version, "v") {
@@ -1137,9 +1121,8 @@ func (m *GitHubReleaseManager) buildFallbackResolution(pkg types.Package, versio
 	return m.buildDeterministicResolution(pkg, version, tagName, plat)
 }
 
-// buildDeterministicResolution builds a resolution from a known tag using url_template or
-// asset_patterns, without any REST API call. When checksum_file is configured it also wires
-// the checksum URL so verification (including strict mode) works without the asset digest.
+// buildDeterministicResolution builds a resolution from a known tag with no REST API call,
+// wiring the checksum_file URL when configured.
 func (m *GitHubReleaseManager) buildDeterministicResolution(pkg types.Package, version, tagName string, plat platform.Platform) (*types.Resolution, error) {
 	// Get the asset pattern for this platform
 	assetPattern, err := manager.ResolveAssetPattern(pkg.AssetPatterns, plat, pkg.Name)

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -170,24 +170,32 @@ func (m *GitHubReleaseManager) Resolve(ctx context.Context, pkg types.Package, v
 	}
 	owner, repo := parts[0], parts[1]
 
-	// No-API fast path for "latest": packages with deterministic asset_patterns and a
-	// checksum_file can be fully resolved without touching the rate-limited REST API.
-	// The tag is resolved via the releases/latest redirect and the checksum comes from
-	// the configured checksum_file (a release asset), so no api.github.com call is made.
-	if version == "latest" && m.canResolveWithoutAPI(pkg, plat) {
-		if resolution, err := m.resolveLatestWithoutAPI(ctx, pkg, owner, repo, plat); err == nil {
-			logger.V(3).Infof("Resolved %s@latest without REST API", pkg.Name)
+	// No-API fast path: packages with a deterministic asset pattern and a checksum_file can
+	// be resolved entirely without the rate-limited REST API — the download URL is computed
+	// from the pattern and the checksum comes from the checksum_file. Covers both "latest"
+	// (tag via the releases/latest redirect) and pinned versions (tag derived from version).
+	if m.canResolveWithoutAPI(pkg, plat) {
+		if resolution, err := m.resolveWithoutAPI(ctx, pkg, owner, repo, version, plat); err == nil {
+			logger.V(3).Infof("Resolved %s@%s without REST API", pkg.Name, version)
 			return resolution, nil
 		} else {
-			logger.V(3).Infof("No-API latest resolution failed for %s: %v, falling back to REST API", pkg.Name, err)
+			logger.V(3).Infof("No-API resolution failed for %s@%s: %v, falling back to REST API", pkg.Name, version, err)
 		}
 	}
 
-	// Fast path: use REST API for "latest" when no url_template is configured
+	// Fast path for "latest" (no url_template). Resolve the concrete tag via the
+	// releases/latest redirect first (no API) so the single REST call is only for the
+	// asset list + digest (the checksum), never for the tag itself.
 	var tagName string
 	if version == "latest" && pkg.URLTemplate == "" {
-		logger.V(3).Infof("Using REST API fast path for latest release of %s/%s", owner, repo)
-		release, err := m.fetchReleaseViaREST(ctx, owner, repo, "latest")
+		endpoint := "latest"
+		if tag, rerr := ResolveLatestTagViaRedirect(ctx, owner, repo); rerr == nil {
+			endpoint = "tags/" + tag
+			logger.V(3).Infof("Resolved %s/%s latest -> %s via redirect (tag without API)", owner, repo, tag)
+		} else {
+			logger.V(3).Infof("latest redirect failed for %s/%s: %v, using REST 'latest'", owner, repo, rerr)
+		}
+		release, err := m.fetchReleaseViaREST(ctx, owner, repo, endpoint)
 		if err == nil {
 			resolution, buildErr := m.buildResolutionFromRelease(pkg, release, plat)
 			if buildErr == nil {
@@ -1053,22 +1061,34 @@ func (m *GitHubReleaseManager) canResolveWithoutAPI(pkg types.Package, plat plat
 		m.hasNonWildcardAssetPattern(pkg, plat)
 }
 
-// resolveLatestWithoutAPI resolves "latest" without the REST API by finding the tag via
-// the releases/latest redirect and building a deterministic resolution whose checksum
-// comes from the configured checksum_file. Returns an error (to fall back to the REST
-// path) if the tag can't be resolved or no checksum source could be derived.
-func (m *GitHubReleaseManager) resolveLatestWithoutAPI(ctx context.Context, pkg types.Package, owner, repo string, plat platform.Platform) (*types.Resolution, error) {
-	tag, err := ResolveLatestTagViaRedirect(ctx, owner, repo)
+// resolveWithoutAPI resolves a version entirely off the REST API for packages that have a
+// deterministic asset pattern and a checksum_file. The tag comes from the releases/latest
+// redirect for "latest", or is derived from the version for pinned versions; the checksum
+// comes from the checksum_file. Returns an error (so the caller falls back to the REST
+// path) for "stable" (needs the release list) or when no checksum source could be derived.
+func (m *GitHubReleaseManager) resolveWithoutAPI(ctx context.Context, pkg types.Package, owner, repo, version string, plat platform.Platform) (*types.Resolution, error) {
+	var resolution *types.Resolution
+	var err error
+
+	switch version {
+	case "latest", "":
+		tag, tagErr := ResolveLatestTagViaRedirect(ctx, owner, repo)
+		if tagErr != nil {
+			return nil, tagErr
+		}
+		logger.V(3).Infof("Resolved latest tag for %s/%s via redirect: %s (no API)", owner, repo, tag)
+		resolution, err = m.buildDeterministicResolution(pkg, versionpkg.Normalize(tag), tag, plat)
+	case "stable":
+		// "stable" needs the release list to pick the first non-prerelease; defer to REST.
+		return nil, fmt.Errorf("no-API path does not support %q", version)
+	default:
+		// Pinned version: derive the tag (typically "v"+version) and build deterministically.
+		resolution, err = m.buildFallbackResolution(pkg, version, plat)
+	}
+
 	if err != nil {
 		return nil, err
 	}
-	logger.V(3).Infof("Resolved latest tag for %s/%s via redirect: %s (no API)", owner, repo, tag)
-
-	resolution, err := m.buildDeterministicResolution(pkg, versionpkg.Normalize(tag), tag, plat)
-	if err != nil {
-		return nil, err
-	}
-
 	if resolution.ChecksumURL == "" && resolution.Checksum == "" {
 		return nil, fmt.Errorf("could not derive checksum source for %s from checksum_file", pkg.Name)
 	}

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -1013,19 +1013,34 @@ func (m *GitHubReleaseManager) handleRateLimitFallback(ctx context.Context, pkg 
 		versionForTemplate = fallbackVersion
 	}
 
-	// For "latest" with no concrete fallback_version, resolve the real tag via redirect
-	// rather than building a bogus "vlatest" URL.
+	var resolution *types.Resolution
+	var err error
 	if versionForTemplate == "latest" || versionForTemplate == "" {
+		// No concrete version to template; resolve the real tag via redirect rather than
+		// building a bogus "vlatest" URL.
 		parts := strings.Split(pkg.Repo, "/")
-		if len(parts) == 2 {
-			if tag, tagErr := ResolveLatestTagViaRedirect(ctx, parts[0], parts[1]); tagErr == nil {
-				return m.buildDeterministicResolution(pkg, versionpkg.Normalize(tag), tag, plat)
-			}
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("rate limited and could not resolve a concrete version for fallback: %w", originalErr)
 		}
-		return nil, fmt.Errorf("rate limited and could not resolve a concrete version for fallback: %w", originalErr)
+		tag, tagErr := ResolveLatestTagViaRedirect(ctx, parts[0], parts[1])
+		if tagErr != nil {
+			return nil, fmt.Errorf("rate limited and could not resolve a concrete version for fallback: %w", originalErr)
+		}
+		resolution, err = m.buildDeterministicResolution(pkg, versionpkg.Normalize(tag), tag, plat)
+	} else {
+		resolution, err = m.buildFallbackResolution(pkg, versionForTemplate, plat)
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	return m.buildFallbackResolution(pkg, versionForTemplate, plat)
+	// checksum_file may fail to resolve a URL (e.g. template/CEL error); strict mode must
+	// still end up with a real checksum source rather than silently skipping verification.
+	if manager.GetStrictChecksum(ctx) && resolution.ChecksumURL == "" && resolution.Checksum == "" {
+		return nil, fmt.Errorf("rate limited and --strict-checksum requires checksum verification: %w", originalErr)
+	}
+
+	return resolution, nil
 }
 
 // hasNonWildcardAssetPattern checks if the package has an asset pattern for the platform
@@ -1084,32 +1099,43 @@ func (m *GitHubReleaseManager) resolveWithoutAPI(ctx context.Context, pkg types.
 	return resolution, nil
 }
 
-// buildChecksumURL turns pkg.ChecksumFile (a full URL, or a release asset name) into a URL.
+// buildChecksumURL turns pkg.ChecksumFile (a full URL, or a release asset name; comma-
+// separated for multiple) into a comma-separated list of URLs.
 func (m *GitHubReleaseManager) buildChecksumURL(pkg types.Package, assetName, version, tag string, plat platform.Platform) string {
 	if pkg.ChecksumFile == "" {
 		return ""
 	}
 
-	checksumFile, err := depstemplate.EvaluateCELOrTemplate(pkg.ChecksumFile, map[string]interface{}{
+	data := map[string]interface{}{
 		"os":      plat.OS,
 		"arch":    plat.Arch,
 		"name":    pkg.Name,
 		"version": depstemplate.NormalizeVersion(version),
 		"tag":     tag,
 		"asset":   assetName,
-	})
-	if err != nil || checksumFile == "" {
-		logger.V(4).Infof("Failed to evaluate checksum_file %q for %s: %v", pkg.ChecksumFile, pkg.Name, err)
-		return ""
 	}
 
-	// Already a full URL (e.g. external checksum host) - use as-is.
-	if hasURLSchema(checksumFile) {
-		return checksumFile
+	var urls []string
+	for _, entry := range strings.Split(pkg.ChecksumFile, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		checksumFile, err := depstemplate.EvaluateCELOrTemplate(entry, data)
+		if err != nil || checksumFile == "" {
+			logger.V(4).Infof("Failed to evaluate checksum_file %q for %s: %v", entry, pkg.Name, err)
+			return ""
+		}
+		if hasURLSchema(checksumFile) {
+			// Already a full URL (e.g. external checksum host) - use as-is.
+			urls = append(urls, checksumFile)
+		} else {
+			// Otherwise it is a release asset name - build the GitHub release download URL.
+			urls = append(urls, fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", pkg.Repo, tag, checksumFile))
+		}
 	}
 
-	// Otherwise it is a release asset name - build the GitHub release download URL.
-	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", pkg.Repo, tag, checksumFile)
+	return strings.Join(urls, ",")
 }
 
 // buildFallbackResolution resolves a pinned version, deriving the tag as "v"+version.

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -170,6 +170,19 @@ func (m *GitHubReleaseManager) Resolve(ctx context.Context, pkg types.Package, v
 	}
 	owner, repo := parts[0], parts[1]
 
+	// No-API fast path for "latest": packages with deterministic asset_patterns and a
+	// checksum_file can be fully resolved without touching the rate-limited REST API.
+	// The tag is resolved via the releases/latest redirect and the checksum comes from
+	// the configured checksum_file (a release asset), so no api.github.com call is made.
+	if version == "latest" && m.canResolveWithoutAPI(pkg, plat) {
+		if resolution, err := m.resolveLatestWithoutAPI(ctx, pkg, owner, repo, plat); err == nil {
+			logger.V(3).Infof("Resolved %s@latest without REST API", pkg.Name)
+			return resolution, nil
+		} else {
+			logger.V(3).Infof("No-API latest resolution failed for %s: %v, falling back to REST API", pkg.Name, err)
+		}
+	}
+
 	// Fast path: use REST API for "latest" when no url_template is configured
 	var tagName string
 	if version == "latest" && pkg.URLTemplate == "" {
@@ -434,6 +447,14 @@ func (m *GitHubReleaseManager) buildResolutionFromRelease(pkg types.Package, rel
 	// Set checksum from digest if available
 	if matched.Digest != "" {
 		resolution.Checksum = matched.Digest // Already in "sha256:..." format from REST API
+	}
+
+	// Wire checksum_file as a checksum source (used when the asset has no digest, and
+	// keeps verification possible without the REST API on subsequent installs).
+	if resolution.Checksum == "" && pkg.ChecksumFile != "" {
+		if checksumURL := m.buildChecksumURL(pkg, matched.Name, version, tagName, plat); checksumURL != "" {
+			resolution.ChecksumURL = checksumURL
+		}
 	}
 
 	if resolution.IsArchive {
@@ -956,8 +977,11 @@ func isRateLimitError(err error) bool {
 // If strict checksum mode is enabled, it returns the error. Otherwise, it builds
 // a resolution without checksum using the fallback version and url_template or asset_patterns.
 func (m *GitHubReleaseManager) handleRateLimitFallback(ctx context.Context, pkg types.Package, version string, plat platform.Platform, originalErr error) (*types.Resolution, error) {
-	// Check if strict checksum mode is enabled
-	if manager.GetStrictChecksum(ctx) {
+	// Strict checksum mode requires a verifiable checksum. The REST API (the usual
+	// source via the asset digest) is rate limited, but a configured checksum_file is
+	// fetched directly from the release assets and is not rate limited — so strict mode
+	// can still be honored when checksum_file is set.
+	if manager.GetStrictChecksum(ctx) && pkg.ChecksumFile == "" {
 		return nil, fmt.Errorf("rate limited and --strict-checksum requires checksum verification: %w", originalErr)
 	}
 
@@ -975,7 +999,11 @@ func (m *GitHubReleaseManager) handleRateLimitFallback(ctx context.Context, pkg 
 		return nil, fmt.Errorf("rate limited and no url_template or asset_patterns configured for fallback: %w", originalErr)
 	}
 
-	logger.Warnf("GitHub rate limited, using fallback version '%s' without checksum verification", fallbackVersion)
+	if pkg.ChecksumFile != "" {
+		logger.Warnf("GitHub rate limited, using fallback version '%s' (checksum verified via checksum_file)", fallbackVersion)
+	} else {
+		logger.Warnf("GitHub rate limited, using fallback version '%s' without checksum verification", fallbackVersion)
+	}
 
 	// Use the requested version for templating if it looks like a specific version
 	versionForTemplate := version
@@ -1001,8 +1029,85 @@ func (m *GitHubReleaseManager) hasNonWildcardAssetPattern(pkg types.Package, pla
 	return !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?")
 }
 
-// buildFallbackResolution builds a resolution using url_template or asset_patterns without checksum
+// canResolveWithoutAPI reports whether a package can be fully resolved without the
+// rate-limited REST API: it needs a deterministic (non-wildcard) asset pattern for the
+// platform to build the download URL, and a checksum_file to verify it. Packages relying
+// on version_expr/version_fallback transforms keep using the REST path for correctness.
+func (m *GitHubReleaseManager) canResolveWithoutAPI(pkg types.Package, plat platform.Platform) bool {
+	return pkg.ChecksumFile != "" &&
+		pkg.VersionExpr == "" &&
+		pkg.VersionFallback == "" &&
+		m.hasNonWildcardAssetPattern(pkg, plat)
+}
+
+// resolveLatestWithoutAPI resolves "latest" without the REST API by finding the tag via
+// the releases/latest redirect and building a deterministic resolution whose checksum
+// comes from the configured checksum_file. Returns an error (to fall back to the REST
+// path) if the tag can't be resolved or no checksum source could be derived.
+func (m *GitHubReleaseManager) resolveLatestWithoutAPI(ctx context.Context, pkg types.Package, owner, repo string, plat platform.Platform) (*types.Resolution, error) {
+	tag, err := ResolveLatestTagViaRedirect(ctx, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	logger.V(3).Infof("Resolved latest tag for %s/%s via redirect: %s (no API)", owner, repo, tag)
+
+	resolution, err := m.buildDeterministicResolution(pkg, versionpkg.Normalize(tag), tag, plat)
+	if err != nil {
+		return nil, err
+	}
+
+	if resolution.ChecksumURL == "" && resolution.Checksum == "" {
+		return nil, fmt.Errorf("could not derive checksum source for %s from checksum_file", pkg.Name)
+	}
+
+	return resolution, nil
+}
+
+// buildChecksumURL constructs the checksum file URL from pkg.ChecksumFile. ChecksumFile
+// may be a CEL expression, a Go template, a full URL, or (most commonly for github_release)
+// a release asset filename, in which case it is resolved to the release's download URL.
+func (m *GitHubReleaseManager) buildChecksumURL(pkg types.Package, assetName, version, tag string, plat platform.Platform) string {
+	if pkg.ChecksumFile == "" {
+		return ""
+	}
+
+	checksumFile, err := depstemplate.EvaluateCELOrTemplate(pkg.ChecksumFile, map[string]interface{}{
+		"os":      plat.OS,
+		"arch":    plat.Arch,
+		"name":    pkg.Name,
+		"version": depstemplate.NormalizeVersion(version),
+		"tag":     tag,
+		"asset":   assetName,
+	})
+	if err != nil || checksumFile == "" {
+		logger.V(4).Infof("Failed to evaluate checksum_file %q for %s: %v", pkg.ChecksumFile, pkg.Name, err)
+		return ""
+	}
+
+	// Already a full URL (e.g. external checksum host) - use as-is.
+	if hasURLSchema(checksumFile) {
+		return checksumFile
+	}
+
+	// Otherwise it is a release asset name - build the GitHub release download URL.
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", pkg.Repo, tag, checksumFile)
+}
+
+// buildFallbackResolution builds a resolution using url_template or asset_patterns when the
+// REST API is unavailable, deriving the tag from the version using the conventional
+// "v"+version GitHub tag format.
 func (m *GitHubReleaseManager) buildFallbackResolution(pkg types.Package, version string, plat platform.Platform) (*types.Resolution, error) {
+	tagName := version
+	if !strings.HasPrefix(version, "v") {
+		tagName = "v" + version
+	}
+	return m.buildDeterministicResolution(pkg, version, tagName, plat)
+}
+
+// buildDeterministicResolution builds a resolution from a known tag using url_template or
+// asset_patterns, without any REST API call. When checksum_file is configured it also wires
+// the checksum URL so verification (including strict mode) works without the asset digest.
+func (m *GitHubReleaseManager) buildDeterministicResolution(pkg types.Package, version, tagName string, plat platform.Platform) (*types.Resolution, error) {
 	// Get the asset pattern for this platform
 	assetPattern, err := manager.ResolveAssetPattern(pkg.AssetPatterns, plat, pkg.Name)
 	if err != nil {
@@ -1014,12 +1119,6 @@ func (m *GitHubReleaseManager) buildFallbackResolution(pkg types.Package, versio
 	}
 	if assetPattern == "" {
 		assetPattern = "{{.name}}-{{.os}}-{{.arch}}"
-	}
-
-	// Determine tag name (typically "v" + version for GitHub releases)
-	tagName := version
-	if !strings.HasPrefix(version, "v") {
-		tagName = "v" + version
 	}
 
 	normalizedVersion := versionpkg.Normalize(version)
@@ -1059,14 +1158,20 @@ func (m *GitHubReleaseManager) buildFallbackResolution(pkg types.Package, versio
 		Platform:    plat,
 		DownloadURL: downloadURL,
 		IsArchive:   isArchiveFile(downloadURL),
-		// No checksum - rate limit fallback
+	}
+
+	// Wire checksum_file -> ChecksumURL so verification works without the REST API digest.
+	if pkg.ChecksumFile != "" {
+		if checksumURL := m.buildChecksumURL(pkg, templatedPattern, normalizedVersion, tagName, plat); checksumURL != "" {
+			resolution.ChecksumURL = checksumURL
+		}
 	}
 
 	if resolution.IsArchive {
 		resolution.BinaryPath = m.guessBinaryPath(pkg, templatedPattern, plat)
 	}
 
-	logger.Debugf("Fallback resolved %s (no checksum)", resolution.Pretty().ANSI())
+	logger.Debugf("Resolved %s", resolution.Pretty().ANSI())
 	return resolution, nil
 }
 

--- a/pkg/manager/github/github_ratelimit_test.go
+++ b/pkg/manager/github/github_ratelimit_test.go
@@ -47,6 +47,17 @@ var _ = Describe("Rate Limit Fallback", func() {
 				Expect(err.Error()).To(ContainSubstring("strict-checksum"))
 				Expect(resolution).To(BeNil())
 			})
+
+			It("should fail when checksum_file is set but yields no checksum URL", func() {
+				pkg.URLTemplate = ""
+				pkg.AssetPatterns = map[string]string{"linux-amd64": "test-tool_{{.tag}}_linux_amd64.tar.gz"}
+				pkg.ChecksumFile = `{{ "" }}` // evaluates to empty -> no checksum URL
+				strictCtx := manager.WithStrictChecksum(ctx, true)
+				resolution, err := mgr.handleRateLimitFallback(strictCtx, pkg, "1.0.0", plat, rateLimitErr)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("strict-checksum"))
+				Expect(resolution).To(BeNil())
+			})
 		})
 
 		Context("with strict checksum disabled", func() {
@@ -148,6 +159,28 @@ var _ = Describe("Rate Limit Fallback", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resolution.IsArchive).To(BeTrue())
 			Expect(resolution.BinaryPath).ToNot(BeEmpty())
+		})
+	})
+
+	Describe("buildChecksumURL", func() {
+		plat := platform.Platform{OS: "linux", Arch: "amd64"}
+
+		It("builds a release download URL from a checksum_file asset name", func() {
+			pkg := types.Package{Name: "postgres", Repo: "flanksource/mission-control-plugins", ChecksumFile: "{{.tag}}_checksums.txt"}
+			Expect(mgr.buildChecksumURL(pkg, "postgres_v1.7.1_linux_amd64.tar.gz", "1.7.1", "v1.7.1", plat)).
+				To(Equal("https://github.com/flanksource/mission-control-plugins/releases/download/v1.7.1/v1.7.1_checksums.txt"))
+		})
+
+		It("builds a comma-separated list for multiple checksum files", func() {
+			pkg := types.Package{Name: "tool", Repo: "o/r", ChecksumFile: "{{.tag}}_checksums.txt, {{.tag}}_sha512.txt"}
+			Expect(mgr.buildChecksumURL(pkg, "tool_linux_amd64.tar.gz", "1.0.0", "v1.0.0", plat)).
+				To(Equal("https://github.com/o/r/releases/download/v1.0.0/v1.0.0_checksums.txt,https://github.com/o/r/releases/download/v1.0.0/v1.0.0_sha512.txt"))
+		})
+
+		It("uses a full checksum URL as-is", func() {
+			pkg := types.Package{Name: "tool", Repo: "o/r", ChecksumFile: "https://example.com/{{.tag}}/checksums.txt"}
+			Expect(mgr.buildChecksumURL(pkg, "tool.tar.gz", "1.0.0", "v1.0.0", plat)).
+				To(Equal("https://example.com/v1.0.0/checksums.txt"))
 		})
 	})
 

--- a/pkg/manager/github/github_ratelimit_test.go
+++ b/pkg/manager/github/github_ratelimit_test.go
@@ -195,6 +195,34 @@ var _ = Describe("Rate Limit Fallback", func() {
 		})
 	})
 
+	Describe("resolveWithoutAPI", func() {
+		plat := platform.Platform{OS: "linux", Arch: "amd64"}
+		pkg := types.Package{
+			Name:          "postgres",
+			Repo:          "flanksource/mission-control-plugins",
+			ChecksumFile:  "{{.tag}}_checksums.txt",
+			AssetPatterns: map[string]string{"linux-amd64": "postgres_{{.tag}}_linux_amd64.tar.gz"},
+		}
+
+		It("resolves a pinned version with no REST API call", func() {
+			res, err := mgr.resolveWithoutAPI(ctx, pkg, "flanksource", "mission-control-plugins", "v1.7.1", plat)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.DownloadURL).To(Equal("https://github.com/flanksource/mission-control-plugins/releases/download/v1.7.1/postgres_v1.7.1_linux_amd64.tar.gz"))
+			Expect(res.ChecksumURL).To(Equal("https://github.com/flanksource/mission-control-plugins/releases/download/v1.7.1/v1.7.1_checksums.txt"))
+		})
+
+		It("derives the v-prefixed tag for a bare pinned version", func() {
+			res, err := mgr.resolveWithoutAPI(ctx, pkg, "flanksource", "mission-control-plugins", "1.7.1", plat)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.DownloadURL).To(ContainSubstring("/download/v1.7.1/postgres_v1.7.1_linux_amd64.tar.gz"))
+		})
+
+		It("defers 'stable' to the REST path", func() {
+			_, err := mgr.resolveWithoutAPI(ctx, pkg, "flanksource", "mission-control-plugins", "stable", plat)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Describe("isRateLimitError", func() {
 		It("should detect rate limit messages in error string", func() {
 			Expect(isRateLimitError(fmt.Errorf("API rate limit exceeded"))).To(BeTrue())

--- a/pkg/manager/github/github_ratelimit_test.go
+++ b/pkg/manager/github/github_ratelimit_test.go
@@ -82,6 +82,20 @@ var _ = Describe("Rate Limit Fallback", func() {
 				Expect(resolution.Checksum).To(BeEmpty())
 			})
 
+			It("should honor strict checksum via checksum_file without the REST API", func() {
+				pkg.URLTemplate = ""
+				pkg.AssetPatterns = map[string]string{
+					"linux-amd64": "test-tool_{{.tag}}_linux_amd64.tar.gz",
+				}
+				pkg.ChecksumFile = "{{.tag}}_checksums.txt"
+				strictCtx := manager.WithStrictChecksum(ctx, true)
+				resolution, err := mgr.handleRateLimitFallback(strictCtx, pkg, "1.0.0", plat, rateLimitErr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolution).ToNot(BeNil())
+				Expect(resolution.DownloadURL).To(Equal("https://github.com/owner/test-tool/releases/download/v1.0.0/test-tool_v1.0.0_linux_amd64.tar.gz"))
+				Expect(resolution.ChecksumURL).To(Equal("https://github.com/owner/test-tool/releases/download/v1.0.0/v1.0.0_checksums.txt"))
+			})
+
 			It("should fail when no url_template and no asset_patterns configured", func() {
 				pkg.URLTemplate = ""
 				pkg.AssetPatterns = nil
@@ -134,6 +148,50 @@ var _ = Describe("Rate Limit Fallback", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resolution.IsArchive).To(BeTrue())
 			Expect(resolution.BinaryPath).ToNot(BeEmpty())
+		})
+	})
+
+	Describe("canResolveWithoutAPI", func() {
+		plat := platform.Platform{OS: "linux", Arch: "amd64"}
+
+		It("should be true for deterministic asset_patterns with a checksum_file", func() {
+			pkg := types.Package{
+				Name:          "postgres",
+				Repo:          "flanksource/mission-control-plugins",
+				ChecksumFile:  "{{.tag}}_checksums.txt",
+				AssetPatterns: map[string]string{"linux-amd64": "postgres_{{.tag}}_linux_amd64.tar.gz"},
+			}
+			Expect(mgr.canResolveWithoutAPI(pkg, plat)).To(BeTrue())
+		})
+
+		It("should be false without a checksum_file", func() {
+			pkg := types.Package{
+				Name:          "postgres",
+				Repo:          "flanksource/mission-control-plugins",
+				AssetPatterns: map[string]string{"linux-amd64": "postgres_{{.tag}}_linux_amd64.tar.gz"},
+			}
+			Expect(mgr.canResolveWithoutAPI(pkg, plat)).To(BeFalse())
+		})
+
+		It("should be false for wildcard asset_patterns", func() {
+			pkg := types.Package{
+				Name:          "tool",
+				Repo:          "owner/tool",
+				ChecksumFile:  "{{.tag}}_checksums.txt",
+				AssetPatterns: map[string]string{"*": "tool-*-{{.os}}-{{.arch}}.tar.gz"},
+			}
+			Expect(mgr.canResolveWithoutAPI(pkg, plat)).To(BeFalse())
+		})
+
+		It("should be false when version_expr is configured", func() {
+			pkg := types.Package{
+				Name:          "tool",
+				Repo:          "owner/tool",
+				ChecksumFile:  "{{.tag}}_checksums.txt",
+				VersionExpr:   "version",
+				AssetPatterns: map[string]string{"linux-amd64": "tool_{{.tag}}_linux_amd64.tar.gz"},
+			}
+			Expect(mgr.canResolveWithoutAPI(pkg, plat)).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving downloads without the GitHub API when release assets and checksum files can be determined directly.
  * Improved handling of the latest release so redirects are followed to the real tag before building download links.
  * Added checksum resolution for cached downloads when a checksum source is available.

* **Bug Fixes**
  * Fixed cases where “latest” could produce invalid `vlatest`-style links.
  * Improved fallback behavior when checksum data can’t be fetched, avoiding unnecessary failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->