### PR TITLE
fix(github): provide version to binary path expressions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 permissions: {} # start with no permission
 
 env:
-  GO_VERSION: "1.26.x"
+  GO_VERSION: "1.26.4"
 
 jobs:
   create-release:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Test action with multiple tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Install Task
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: |
             go.sum
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Install Task

--- a/e2e/helpers/registry.go
+++ b/e2e/helpers/registry.go
@@ -197,7 +197,7 @@ func ExtractSupportedPlatforms(pkg types.Package) []string {
 	}
 
 	// Handle URL template based packages (kubectl, terraform, etc.)
-	if pkg.URLTemplate != "" {
+	if pkg.URLTemplate != "" && len(pkg.AssetPatterns) == 0 {
 		// These typically support many platforms via template variables
 		// Add common combinations for testing
 		commonPlatforms := []string{

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -881,7 +881,7 @@ registry:
             linux-arm64: rclone-{{.tag}}-linux-arm64.zip
             windows-amd64: rclone-{{.tag}}-windows-amd64.zip
         binary_path: |
-            "rclone-v" + version + "-" + (os == "darwin" ? "osx" : os) + "-" + arch + "/rclone"
+            "rclone-v" + version + "-" + (os == "darwin" ? "osx" : os) + "-" + arch + "/rclone" + (os == "windows" ? ".exe" : "")
         version_command: --version
         version_regex: 'rclone v(\d+\.\d+\.\d+)'
 

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -462,7 +462,7 @@ func (m *GitHubReleaseManager) buildResolutionFromRelease(pkg types.Package, rel
 	}
 
 	if resolution.IsArchive {
-		resolution.BinaryPath = m.guessBinaryPath(pkg, matched.Name, plat)
+		resolution.BinaryPath = m.guessBinaryPath(pkg, matched.Name, version, plat)
 	}
 
 	logger.Debugf("Resolved %s", resolution.Pretty().ANSI())
@@ -653,7 +653,7 @@ assetFound:
 		if githubAsset != nil {
 			assetName = githubAsset.AssetName
 		}
-		resolution.BinaryPath = m.guessBinaryPath(pkg, assetName, plat)
+		resolution.BinaryPath = m.guessBinaryPath(pkg, assetName, version, plat)
 	}
 
 	if assetSHA256 != "" {
@@ -1210,7 +1210,7 @@ func (m *GitHubReleaseManager) buildDeterministicResolution(pkg types.Package, v
 	}
 
 	if resolution.IsArchive {
-		resolution.BinaryPath = m.guessBinaryPath(pkg, templatedPattern, plat)
+		resolution.BinaryPath = m.guessBinaryPath(pkg, templatedPattern, normalizedVersion, plat)
 	}
 
 	logger.Debugf("Resolved %s", resolution.Pretty().ANSI())
@@ -1244,12 +1244,13 @@ func (m *GitHubReleaseManager) enhanceErrorWithVersions(ctx context.Context, pkg
 	return manager.EnhanceErrorWithVersions(pkg.Name, requestedVersion, versions, originalErr)
 }
 
-func (m *GitHubReleaseManager) guessBinaryPath(pkg types.Package, assetName string, plat platform.Platform) string {
+func (m *GitHubReleaseManager) guessBinaryPath(pkg types.Package, assetName, version string, plat platform.Platform) string {
 	if pkg.BinaryPath != "" {
 		data := map[string]any{
-			"os":   plat.OS,
-			"arch": plat.Arch,
-			"name": pkg.Name,
+			"os":      plat.OS,
+			"arch":    plat.Arch,
+			"name":    pkg.Name,
+			"version": version,
 		}
 
 		result, err := depstemplate.EvaluateCELOrTemplate(pkg.BinaryPath, data)

--- a/pkg/manager/github/github.go
+++ b/pkg/manager/github/github.go
@@ -462,7 +462,7 @@ func (m *GitHubReleaseManager) buildResolutionFromRelease(pkg types.Package, rel
 	}
 
 	if resolution.IsArchive {
-		resolution.BinaryPath = m.guessBinaryPath(pkg, matched.Name, version, plat)
+		resolution.BinaryPath = m.guessBinaryPath(pkg, matched.Name, version, tagName, plat)
 	}
 
 	logger.Debugf("Resolved %s", resolution.Pretty().ANSI())
@@ -653,7 +653,7 @@ assetFound:
 		if githubAsset != nil {
 			assetName = githubAsset.AssetName
 		}
-		resolution.BinaryPath = m.guessBinaryPath(pkg, assetName, version, plat)
+		resolution.BinaryPath = m.guessBinaryPath(pkg, assetName, version, tagName, plat)
 	}
 
 	if assetSHA256 != "" {
@@ -1210,7 +1210,7 @@ func (m *GitHubReleaseManager) buildDeterministicResolution(pkg types.Package, v
 	}
 
 	if resolution.IsArchive {
-		resolution.BinaryPath = m.guessBinaryPath(pkg, templatedPattern, normalizedVersion, plat)
+		resolution.BinaryPath = m.guessBinaryPath(pkg, templatedPattern, normalizedVersion, tagName, plat)
 	}
 
 	logger.Debugf("Resolved %s", resolution.Pretty().ANSI())
@@ -1244,13 +1244,15 @@ func (m *GitHubReleaseManager) enhanceErrorWithVersions(ctx context.Context, pkg
 	return manager.EnhanceErrorWithVersions(pkg.Name, requestedVersion, versions, originalErr)
 }
 
-func (m *GitHubReleaseManager) guessBinaryPath(pkg types.Package, assetName, version string, plat platform.Platform) string {
+func (m *GitHubReleaseManager) guessBinaryPath(pkg types.Package, assetName, version, tagName string, plat platform.Platform) string {
 	if pkg.BinaryPath != "" {
 		data := map[string]any{
 			"os":      plat.OS,
 			"arch":    plat.Arch,
 			"name":    pkg.Name,
 			"version": version,
+			"tag":     tagName,
+			"asset":   assetName,
 		}
 
 		result, err := depstemplate.EvaluateCELOrTemplate(pkg.BinaryPath, data)

--- a/pkg/manager/github/github_binary_path_test.go
+++ b/pkg/manager/github/github_binary_path_test.go
@@ -16,8 +16,21 @@ var _ = Describe("GitHubReleaseManager binary path", func() {
 		}
 		plat := platform.Platform{OS: "windows", Arch: "amd64"}
 
-		path := manager.guessBinaryPath(pkg, "rclone-v1.74.4-windows-amd64.zip", "1.74.4", plat)
+		path := manager.guessBinaryPath(pkg, "rclone-v1.74.4-windows-amd64.zip", "1.74.4", "v1.74.4", plat)
 
 		Expect(path).To(Equal("rclone-v1.74.4-windows-amd64/rclone.exe"))
+	})
+
+	It("provides the release tag and asset name to templates", func() {
+		manager := NewGitHubReleaseManager()
+		pkg := types.Package{
+			Name:       "nats-server",
+			BinaryPath: `asset.startsWith("nats-server-" + tag) ? "nats-server-" + tag + "-" + os + "-" + arch + "/nats-server" : ""`,
+		}
+		plat := platform.Platform{OS: "linux", Arch: "amd64"}
+
+		path := manager.guessBinaryPath(pkg, "nats-server-v2.12.3-linux-amd64.tar.gz", "2.12.3", "v2.12.3", plat)
+
+		Expect(path).To(Equal("nats-server-v2.12.3-linux-amd64/nats-server"))
 	})
 })

--- a/pkg/manager/github/github_binary_path_test.go
+++ b/pkg/manager/github/github_binary_path_test.go
@@ -1,0 +1,23 @@
+package github
+
+import (
+	"github.com/flanksource/deps/pkg/platform"
+	"github.com/flanksource/deps/pkg/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GitHubReleaseManager binary path", func() {
+	It("provides the resolved version to CEL expressions", func() {
+		manager := NewGitHubReleaseManager()
+		pkg := types.Package{
+			Name:       "rclone",
+			BinaryPath: `"rclone-v" + version + "-" + os + "-" + arch + "/rclone" + (os == "windows" ? ".exe" : "")`,
+		}
+		plat := platform.Platform{OS: "windows", Arch: "amd64"}
+
+		path := manager.guessBinaryPath(pkg, "rclone-v1.74.4-windows-amd64.zip", "1.74.4", plat)
+
+		Expect(path).To(Equal("rclone-v1.74.4-windows-amd64/rclone.exe"))
+	})
+})

--- a/start/start.go
+++ b/start/start.go
@@ -172,7 +172,7 @@ func mergePriorOptions(options *Options, prior *state.State) error {
 	if !options.supplied.namespace && saved.Namespace != "" {
 		options.Namespace = saved.Namespace
 	}
-	if !options.supplied.dataDir && !(options.supplied.volumeMode && options.VolumeMode != VolumeHost) {
+	if !options.supplied.dataDir && (!options.supplied.volumeMode || options.VolumeMode == VolumeHost) {
 		options.DataDir = saved.DataDir
 	}
 	if !options.supplied.volumeMode && !options.supplied.dataDir {


### PR DESCRIPTION
The rclone Windows installation exposed a latent GitHub asset resolution bug after v1.74.4 stopped carrying executable permission metadata.

GitHub binary path CEL expressions could reference `version`, but the evaluator only received `name`, `os`, and `arch`. Evaluation therefore failed and silently fell back to executable scanning.

Pass the resolved version into the CEL context and include the `.exe` suffix in rclone’s Windows binary path so the extracted file is located explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows support by correctly resolving executable paths with the `.exe` suffix.
  - Binary paths can now vary based on the selected tool version and platform.
  - Fixed archive-based installations to consistently locate the expected executable.

- **Tests**
  - Added coverage for version- and platform-specific binary path resolution, including Windows archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->