### PR TITLE
fix(config): correct SOPS checksum filename

### DIFF
--- a/pkg/config/config_ginkgo_test.go
+++ b/pkg/config/config_ginkgo_test.go
@@ -15,6 +15,7 @@ var _ = Describe("Config", func() {
 			Expect(len(config.Registry)).To(BeNumerically(">", 50))
 			Expect(config.Registry).To(HaveKey("powershell"))
 			Expect(config.Registry).To(HaveKey("step"))
+			Expect(config.Registry["sops"].ChecksumFile).To(Equal("sops-v{{.version}}.checksums.txt"))
 		})
 	})
 

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -218,7 +218,7 @@ registry:
     sops:
         name: sops
         repo: getsops/sops
-        checksum_file: sops-{{.version}}.checksums.txt
+        checksum_file: sops-v{{.version}}.checksums.txt
         asset_patterns:
             "*": "sops-{{.tag}}.{{.os}}.{{.arch}}"
 


### PR DESCRIPTION
SOPS publishes checksum manifests as `sops-v${version}.checksums.txt`.

The default registry omitted the `v`, causing checksum lookup failures during SOPS installation. Update the checksum template and add a regression assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the SOPS dependency checksum filename format to include the `v` prefix.
  * Added verification to ensure the default configuration uses the expected checksum template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->