### PR TITLE
fix(ci): provide token to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,9 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    uses: flanksource/action-workflows/.github/workflows/create-release.yml@main
+    uses: flanksource/action-workflows/.github/workflows/create-release.yml@c628197234fd2c4c3aebcb3c2b60dd399251adaf
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   binary:
     name: Build binaries


### PR DESCRIPTION
Release runs failed validation because the shared workflow requires an explicit token secret. Pass the ephemeral GITHUB_TOKEN with the job's write permissions and pin the shared workflow to an immutable commit SHA.