### PR TITLE
fix(ci): use Flankbot for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     uses: flanksource/action-workflows/.github/workflows/create-release.yml@c628197234fd2c4c3aebcb3c2b60dd399251adaf
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.FLANKBOT }}
 
   binary:
     name: Build binaries


### PR DESCRIPTION
The shared release workflow removes permissions from the ephemeral `GITHUB_TOKEN`, causing semantic-release’s push check to fail with HTTP 403.

Pass the `FLANKBOT` credential so release tags and GitHub releases can be created.