### PR TITLE
fix: use job-scoped token for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    uses: flanksource/action-workflows/.github/workflows/create-release.yml@c628197234fd2c4c3aebcb3c2b60dd399251adaf
-    secrets:
-      token: ${{ secrets.FLANKBOT }}
+    uses: flanksource/action-workflows/.github/workflows/create-release.yml@f8512a65d38c1ea53d5c83a4e30ee2ae56acac6f
 
   binary:
     name: Build binaries


### PR DESCRIPTION
The release workflow passed `FLANKBOT` explicitly to the reusable create-release workflow.

Update action-workflows to the latest pinned SHA and remove the custom token, allowing create-release to use its own job-scoped GitHub token with the declared permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow to use a newer release process.
  * Improved release workflow security by removing an unnecessary token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->