### PR TITLE
fix: check installed binaries before remote version resolution

### DIFF
--- a/pkg/config/config_ginkgo_test.go
+++ b/pkg/config/config_ginkgo_test.go
@@ -43,6 +43,21 @@ var _ = Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(installed).To(Equal("0.6.7"))
 		})
+
+		It("should parse canonical and legacy PostgREST versions", func() {
+			config, err := LoadDefaultConfig()
+			Expect(err).ToNot(HaveOccurred())
+
+			pattern := config.Registry["postgrest"].VersionRegex
+			for output, expected := range map[string]string{
+				"PostgREST 14.6":   "14.6",
+				"PostgREST 13.0.5": "13.0.5",
+			} {
+				installed, err := version.ExtractFromOutput(output, pattern)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(installed).To(Equal(expected))
+			}
+		})
 	})
 
 	Describe("Package Defaults", func() {

--- a/pkg/config/defaults.yaml
+++ b/pkg/config/defaults.yaml
@@ -331,7 +331,7 @@ registry:
             linux-arm64: postgrest-{{.tag}}-ubuntu-aarch64.tar.xz
             windows-amd64: postgrest-{{.tag}}-windows-x86-64.zip
         version_command: --help
-        version_regex: .*PostgREST\s+v?(\d+\.\d+\.\d+)
+        version_regex: .*PostgREST\s+v?(\d+\.\d+(\.\d+)?)
     wal-g:
         name: wal-g
 

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -205,23 +205,12 @@ func (i *Installer) InstallFromConfig(t *task.Task) error {
 					return nil, err
 				}
 
-				// Resolve version constraint if not already resolved from lock file
-				resolvedVersion := version
-				if resolvedVersion == "" {
-					task.V(3).Infof("Resolving version constraint '%s' for %s", depConstraint, depName)
-					mgr, err := i.managers.GetForPackage(pkg)
-					if err != nil {
-						return nil, fmt.Errorf("failed to get package manager for %s: %w", depName, err)
-					}
-
-					resolvedVersion, err = i.resolveVersionConstraint(i.managerContext(ctx.Context), mgr, pkg, depConstraint, task)
-					if err != nil {
-						return nil, fmt.Errorf("failed to resolve version constraint for %s: %w", depName, err)
-					}
-					task.Infof("Resolved %s version: %s -> %s", depName, depConstraint, resolvedVersion)
+				requestedVersion := version
+				if requestedVersion == "" {
+					requestedVersion = depConstraint
 				}
 
-				return nil, i.installWithNewPackageManager(ctx.Context, depName, resolvedVersion, pkg, task)
+				return nil, i.installWithNewPackageManager(ctx.Context, depName, requestedVersion, pkg, task)
 			} else {
 				return nil, fmt.Errorf("dependency %s not found in registry - please add it to deps.yaml registry section", depName)
 			}

--- a/pkg/installer/installer_suite_test.go
+++ b/pkg/installer/installer_suite_test.go
@@ -1,11 +1,34 @@
 package installer
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+const (
+	postgrestHelperVersionEnv = "DEPS_TEST_POSTGREST_VERSION"
+	postgrestHelperMarkerEnv  = "DEPS_TEST_POSTGREST_MARKER"
+)
+
+func TestMain(m *testing.M) {
+	if version := os.Getenv(postgrestHelperVersionEnv); version != "" {
+		if len(os.Args) != 2 || os.Args[1] != "--help" {
+			os.Exit(2)
+		}
+		if marker := os.Getenv(postgrestHelperMarkerEnv); marker != "" {
+			if err := os.WriteFile(marker, nil, 0600); err != nil {
+				os.Exit(2)
+			}
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "PostgREST %s\nUsage: postgrest FILENAME\n  postgrest --help\n", version)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 func TestInstaller(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/installer/preview.go
+++ b/pkg/installer/preview.go
@@ -124,6 +124,22 @@ func (i *Installer) previewPackageInstallation(ctx context.Context, name, versio
 	}
 	preview.RequestedVersion = requestedVersion
 
+	markExisting := func(existingVersion string) *InstallPreview {
+		preview.AlreadyInstalled = true
+		preview.ExistingVersion = existingVersion
+		if path, ok := i.getInstalledPath(name, pkg); ok {
+			preview.ExistingPath = path
+		}
+		return preview
+	}
+
+	if !i.options.Force && len(i.options.AssetFilters) == 0 {
+		existingVersion := i.checkExistingInstallation(t, name, pkg, requestedVersion)
+		if existingVersion != "" && versionpkg.Normalize(existingVersion) == versionpkg.Normalize(requestedVersion) {
+			return markExisting(existingVersion), nil
+		}
+	}
+
 	t.SetDescription(fmt.Sprintf("Resolving version %s", requestedVersion))
 	resolveCtx := i.managerContext(ctx)
 	resolvedVersion, err := i.resolveVersionConstraint(resolveCtx, mgr, pkg, requestedVersion, t)
@@ -133,29 +149,8 @@ func (i *Installer) previewPackageInstallation(ctx context.Context, name, versio
 	preview.ResolvedVersion = resolvedVersion
 
 	if !i.options.Force && len(i.options.AssetFilters) == 0 {
-		if i.options.ArchOverride != "" {
-			binaryName := name
-			if pkg.BinaryName != "" {
-				binaryName = pkg.BinaryName
-			}
-			binPath := filepath.Join(i.options.BinDir, binaryName)
-			if nativeArch := pipeline.DetectBinaryArch(binPath); nativeArch != "" && !archMatches(nativeArch, i.options.ArchOverride) {
-				t.Debugf("Existing %s is %s but %s requested, reinstalling", binaryName, nativeArch, i.options.ArchOverride)
-			} else if existingVersion := versionpkg.CheckExistingInstallation(t, name, pkg, resolvedVersion, i.options.BinDir, i.options.OSOverride); existingVersion != "" {
-				preview.AlreadyInstalled = true
-				preview.ExistingVersion = existingVersion
-				if path, ok := i.getInstalledPath(name, pkg); ok {
-					preview.ExistingPath = path
-				}
-				return preview, nil
-			}
-		} else if existingVersion := versionpkg.CheckExistingInstallation(t, name, pkg, resolvedVersion, i.options.BinDir, i.options.OSOverride); existingVersion != "" {
-			preview.AlreadyInstalled = true
-			preview.ExistingVersion = existingVersion
-			if path, ok := i.getInstalledPath(name, pkg); ok {
-				preview.ExistingPath = path
-			}
-			return preview, nil
+		if existingVersion := i.checkExistingInstallation(t, name, pkg, resolvedVersion); existingVersion != "" {
+			return markExisting(existingVersion), nil
 		}
 	}
 
@@ -205,6 +200,22 @@ func (i *Installer) findExistingAnyInstallation(name string, pkg types.Package) 
 	}
 
 	return "", "", false
+}
+
+func (i *Installer) checkExistingInstallation(t *task.Task, name string, pkg types.Package, requestedVersion string) string {
+	if i.options.ArchOverride != "" {
+		binaryName := name
+		if pkg.BinaryName != "" {
+			binaryName = pkg.BinaryName
+		}
+		binPath := filepath.Join(i.options.BinDir, binaryName)
+		if nativeArch := pipeline.DetectBinaryArch(binPath); nativeArch != "" && !archMatches(nativeArch, i.options.ArchOverride) {
+			t.Debugf("Existing %s is %s but %s requested, reinstalling", binaryName, nativeArch, i.options.ArchOverride)
+			return ""
+		}
+	}
+
+	return versionpkg.CheckExistingInstallation(t, name, pkg, requestedVersion, i.options.BinDir, i.options.OSOverride)
 }
 
 func (i *Installer) getInstalledPath(name string, pkg types.Package) (string, bool) {

--- a/pkg/installer/preview.go
+++ b/pkg/installer/preview.go
@@ -208,6 +208,9 @@ func (i *Installer) checkExistingInstallation(t *task.Task, name string, pkg typ
 		if pkg.BinaryName != "" {
 			binaryName = pkg.BinaryName
 		}
+		if i.options.OSOverride == "windows" && filepath.Ext(binaryName) == "" {
+			binaryName += ".exe"
+		}
 		binPath := filepath.Join(i.options.BinDir, binaryName)
 		if nativeArch := pipeline.DetectBinaryArch(binPath); nativeArch != "" && !archMatches(nativeArch, i.options.ArchOverride) {
 			t.Debugf("Existing %s is %s but %s requested, reinstalling", binaryName, nativeArch, i.options.ArchOverride)

--- a/pkg/installer/preview_test.go
+++ b/pkg/installer/preview_test.go
@@ -2,32 +2,41 @@ package installer
 
 import (
 	"context"
+	"errors"
+	"io"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/flanksource/clicky/task"
 	"github.com/flanksource/deps/mock"
+	"github.com/flanksource/deps/pkg/config"
 	"github.com/flanksource/deps/pkg/manager"
 	"github.com/flanksource/deps/pkg/platform"
 	"github.com/flanksource/deps/pkg/types"
 )
 
 type previewResolverManager struct {
-	name       string
-	resolved   string
-	resolution *types.Resolution
-	discover   []types.Version
-	resolveErr error
-	installErr error
+	name        string
+	resolved    string
+	resolution  *types.Resolution
+	discover    []types.Version
+	resolveErr  error
+	installErr  error
+	remoteCalls int
 }
 
 func (m *previewResolverManager) Name() string { return m.name }
 
 func (m *previewResolverManager) DiscoverVersions(ctx context.Context, pkg types.Package, plat platform.Platform, limit int) ([]types.Version, error) {
+	m.remoteCalls++
 	return m.discover, nil
 }
 
 func (m *previewResolverManager) Resolve(ctx context.Context, pkg types.Package, version string, plat platform.Platform) (*types.Resolution, error) {
+	m.remoteCalls++
 	if m.resolveErr != nil {
 		return nil, m.resolveErr
 	}
@@ -39,10 +48,12 @@ func (m *previewResolverManager) Resolve(ctx context.Context, pkg types.Package,
 }
 
 func (m *previewResolverManager) Install(ctx context.Context, resolution *types.Resolution, opts types.InstallOptions) error {
+	m.remoteCalls++
 	return m.installErr
 }
 
 func (m *previewResolverManager) GetChecksums(ctx context.Context, pkg types.Package, version string) (map[string]string, error) {
+	m.remoteCalls++
 	return nil, nil
 }
 
@@ -51,7 +62,175 @@ func (m *previewResolverManager) Verify(ctx context.Context, binaryPath string, 
 }
 
 func (m *previewResolverManager) ResolveVersionConstraint(ctx context.Context, pkg types.Package, constraint string, plat platform.Platform) (string, error) {
+	m.remoteCalls++
+	if m.resolveErr != nil {
+		return "", m.resolveErr
+	}
 	return m.resolved, nil
+}
+
+func writePostgRESTTestBinary(t *testing.T, binDir, version string) string {
+	t.Helper()
+
+	sourcePath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("find test executable: %v", err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatalf("open test executable: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	binaryName := "postgrest"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(binDir, binaryName)
+	destination, err := os.OpenFile(binaryPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		t.Fatalf("create fake postgrest: %v", err)
+	}
+	if _, err := io.Copy(destination, source); err != nil {
+		_ = destination.Close()
+		t.Fatalf("copy test executable: %v", err)
+	}
+	if err := destination.Close(); err != nil {
+		t.Fatalf("close fake postgrest: %v", err)
+	}
+
+	markerPath := filepath.Join(binDir, "postgrest-invoked")
+	t.Setenv(postgrestHelperVersionEnv, version)
+	t.Setenv(postgrestHelperMarkerEnv, markerPath)
+	return markerPath
+}
+
+func TestInstallPostgRESTCanonicalVersionWithoutRemoteResolution(t *testing.T) {
+	const managerName = "mock-postgrest-airgap"
+	mgr := &previewResolverManager{
+		name:       managerName,
+		resolveErr: errors.New("remote version resolution invoked"),
+		resolution: &types.Resolution{},
+	}
+	manager.GetGlobalRegistry().Register(mgr)
+
+	defaults, err := config.LoadDefaultConfig()
+	if err != nil {
+		t.Fatalf("load default config: %v", err)
+	}
+	pkg := defaults.Registry["postgrest"]
+	pkg.Manager = managerName
+
+	binDir := t.TempDir()
+	markerPath := writePostgRESTTestBinary(t, binDir, "14.6")
+
+	inst := NewWithConfig(
+		&types.DepsConfig{Registry: map[string]types.Package{"postgrest": pkg}},
+		WithBinDir(binDir),
+		WithOS(runtime.GOOS, runtime.GOARCH),
+	)
+	result, err := inst.InstallWithResult("postgrest", "v14.6", &task.Task{})
+	if err != nil {
+		t.Fatalf("install matching local postgrest: %v", err)
+	}
+	if result.Status != types.InstallStatusAlreadyInstalled {
+		t.Fatalf("expected already installed status, got %s", result.Status)
+	}
+	if result.Version.Version != "v14.6" {
+		t.Fatalf("expected requested version v14.6, got %s", result.Version.Version)
+	}
+	if mgr.remoteCalls != 0 {
+		t.Fatalf("expected no remote discovery or resolution, got %d calls", mgr.remoteCalls)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected postgrest version command to run: %v", err)
+	}
+}
+
+func TestInstallFromConfigPostgRESTCanonicalVersionWithoutRemoteResolution(t *testing.T) {
+	const managerName = "mock-postgrest-config-airgap"
+	mgr := &previewResolverManager{
+		name:       managerName,
+		resolveErr: errors.New("remote version resolution invoked"),
+		resolution: &types.Resolution{},
+	}
+	manager.GetGlobalRegistry().Register(mgr)
+
+	defaults, err := config.LoadDefaultConfig()
+	if err != nil {
+		t.Fatalf("load default config: %v", err)
+	}
+	pkg := defaults.Registry["postgrest"]
+	pkg.Manager = managerName
+	testConfig := &types.DepsConfig{
+		Dependencies: map[string]string{"postgrest": "v14.6"},
+		Registry:     map[string]types.Package{"postgrest": pkg},
+	}
+	previousConfig := config.GetGlobalRegistry()
+	config.SetGlobalRegistry(testConfig)
+	t.Cleanup(func() { config.SetGlobalRegistry(previousConfig) })
+
+	binDir := t.TempDir()
+	markerPath := writePostgRESTTestBinary(t, binDir, "14.6")
+	t.Chdir(t.TempDir())
+	inst := New(
+		WithBinDir(binDir),
+		WithOS(runtime.GOOS, runtime.GOARCH),
+	)
+	if err := inst.InstallFromConfig(&task.Task{}); err != nil {
+		t.Fatalf("install from config: %v", err)
+	}
+	task.WaitForAllTasks()
+
+	if mgr.remoteCalls != 0 {
+		t.Fatalf("expected no remote discovery or resolution, got %d calls", mgr.remoteCalls)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected postgrest version command to run: %v", err)
+	}
+}
+
+func TestInstallPostgRESTResolvesWhenLocalBinaryDoesNotMatch(t *testing.T) {
+	for _, localVersion := range []string{"", "14.5"} {
+		name := "absent"
+		if localVersion != "" {
+			name = "mismatched"
+		}
+		t.Run(name, func(t *testing.T) {
+			managerName := "mock-postgrest-" + name
+			mgr := &previewResolverManager{
+				name:       managerName,
+				resolveErr: errors.New("remote version resolution invoked"),
+				resolution: &types.Resolution{},
+			}
+			manager.GetGlobalRegistry().Register(mgr)
+
+			defaults, err := config.LoadDefaultConfig()
+			if err != nil {
+				t.Fatalf("load default config: %v", err)
+			}
+			pkg := defaults.Registry["postgrest"]
+			pkg.Manager = managerName
+
+			binDir := t.TempDir()
+			if localVersion != "" {
+				writePostgRESTTestBinary(t, binDir, localVersion)
+			}
+
+			inst := NewWithConfig(
+				&types.DepsConfig{Registry: map[string]types.Package{"postgrest": pkg}},
+				WithBinDir(binDir),
+				WithOS(runtime.GOOS, runtime.GOARCH),
+			)
+			_, err = inst.InstallWithResult("postgrest", "v14.6", &task.Task{})
+			if err == nil || !strings.Contains(err.Error(), "remote version resolution invoked") {
+				t.Fatalf("expected remote resolution attempt, got %v", err)
+			}
+			if mgr.remoteCalls != 1 {
+				t.Fatalf("expected one remote resolution call, got %d", mgr.remoteCalls)
+			}
+		})
+	}
 }
 
 func TestPreviewUsesExistingBinaryForAny(t *testing.T) {


### PR DESCRIPTION
Installing PostgREST v14.6 in an air-gapped environment failed even when a matching local binary was present.

Two-component versions were treated as constraints and resolved remotely before checking the installed binary, while the PostgREST registry regex only accepted three-component output.

Check exact normalized local versions before constraint resolution, route config-based installs through the same path, and accept both canonical two-component and legacy three-component PostgREST versions. Missing or mismatched installations continue through normal remote resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgREST version handling to support both two-part and three-part version formats.
  - Installation previews now correctly recognize matching local installations and show existing version and path details.
  - Avoided unnecessary remote version lookups when the requested version is already installed.
  - Remote resolution still occurs when PostgREST is missing or the installed version does not match.
  - Configuration-based installations now use the selected or locked version consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->