### PR TITLE
fix(start): accept ready state

### DIFF
--- a/start/cmd/deps-start/detach.go
+++ b/start/cmd/deps-start/detach.go
@@ -101,13 +101,14 @@ func awaitDetachedReady(name, stateDir, logPath string, pid int, exited <-chan e
 	deadline := time.Now().Add(timeout)
 	stateFile := filepath.Join(stateDir, name, "state.yaml")
 	for time.Now().Before(deadline) {
-		if info, err := os.Stat(stateFile); err == nil && info.ModTime().After(spawned) {
-			if st, err := state.Load(stateDir, name); err == nil && st.Ready {
-				return nil
-			}
+		if detachedReady(stateDir, name, stateFile, spawned) {
+			return nil
 		}
 		select {
 		case err := <-exited:
+			if detachedReady(stateDir, name, stateFile, spawned) {
+				return nil
+			}
 			return &startFailure{
 				code: supervisorExitCode(err),
 				err:  fmt.Errorf("%s failed to start, see %s:\n%s", name, logPath, tailFile(logPath, 20)),
@@ -117,4 +118,13 @@ func awaitDetachedReady(name, stateDir, logPath string, pid int, exited <-chan e
 	}
 	return fmt.Errorf("timed out after %s waiting for %s to become ready; it is still starting (supervisor pid %d), follow it with `deps-start logs %s -f`",
 		timeout, name, pid, name)
+}
+
+func detachedReady(stateDir, name, stateFile string, spawned time.Time) bool {
+	info, err := os.Stat(stateFile)
+	if err != nil || !info.ModTime().After(spawned) {
+		return false
+	}
+	st, err := state.Load(stateDir, name)
+	return err == nil && st.Ready
 }

--- a/start/cmd/deps-start/exit_test.go
+++ b/start/cmd/deps-start/exit_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	osexec "os/exec"
+	"time"
 
+	"github.com/flanksource/deps/start/state"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -42,5 +44,24 @@ var _ = Describe("startFailure", func() {
 		Expect(failure.code).To(Equal(3))
 		Expect(err.Error()).To(Equal(cause.Error()))
 		Expect(errors.Is(err, cause)).To(BeTrue())
+	})
+})
+
+var _ = Describe("awaitDetachedReady", func() {
+	It("accepts a ready state published immediately before a clean supervisor exit", func() {
+		stateDir := GinkgoT().TempDir()
+		exited := make(chan error, 1)
+		saved := make(chan error, 1)
+		spawned := time.Now()
+
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			saved <- (&state.State{Name: "opensearch", Ready: true}).Save(stateDir)
+			close(exited)
+		}()
+
+		err := awaitDetachedReady("opensearch", stateDir, "supervisor.log", 1234, exited, spawned, time.Second)
+		Expect(<-saved).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
### What
- Accept the ready state before supervisor exit.
- Add coverage for the exit behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detached dependency startup detection to recognize readiness reported just before the supervisor exits.
  - Prevented valid startup states from being incorrectly reported as failures.
  - Improved validation of state updates to ensure only current readiness information is accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->